### PR TITLE
Compression API

### DIFF
--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\streams\compress\{Algorithm, Algorithms, Brotli, Bzip2, Gzip};
+use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip};
 use lang\IllegalArgumentException;
 
 /**
@@ -19,14 +19,7 @@ abstract class Compression {
   private static $algorithms;
 
   static function __static() {
-    self::$NONE= new class() implements Algorithm {
-      public function supported(): bool { return true; }
-      public function name(): string { return 'none'; }
-      public function token(): string { return 'identity'; }
-      public function extension(): string { return ''; }
-      public function open(InputStream $in): InputStream { return $in; }
-      public function create(OutputStream $out, int $method): OutputStream { return $out; }
-    };
+    self::$NONE= new None();
 
     // Register known algorithms included in this library
     self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli());

--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,0 +1,124 @@
+<?php namespace io\streams;
+
+use io\streams\compress\{
+  GzipInputStream,
+  GzipOutputStream,
+  Bzip2InputStream,
+  Bzip2OutputStream,
+  BrotliInputStream,
+  BrotliOutputStream
+};
+use lang\{Enum, IllegalArgumentException};
+
+/**
+ * Compression algorithms enumeration
+ *
+ * @see   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+ * @see   https://en.wikipedia.org/wiki/HTTP_compression#Content-Encoding_tokens
+ * @test  io.streams.compress.unittest.CompressionTest
+ */
+abstract class Compression extends Enum {
+  const FASTEST   = 0;
+  const DEFAULT   = 1;
+  const STRONGEST = 2;
+
+  public static $NONE, $GZIP, $BZIP2, $BROTLI;
+
+  static function __static() {
+    self::$NONE= new class(0, 'NONE') extends Compression {
+      public function supported(): bool { return true; }
+      public function token(): string { return 'identity'; }
+      public function extension(): string { return ''; }
+      public function open($in) { return $in; }
+      public function create($out, $method) { return $out; }
+    };
+
+    self::$GZIP= new class(1, 'GZIP') extends Compression {
+      const LEVELS= [
+        Compression::FASTEST   => 1,
+        Compression::DEFAULT   => 6,
+        Compression::STRONGEST => 9,
+      ];
+
+      public function supported(): bool { return extension_loaded('zlib'); }
+      public function token(): string { return 'gzip'; }
+      public function extension(): string { return '.gz'; }
+      public function open($in) { return new GzipInputStream($in); }
+      public function create($out, $method= Compression::DEFAULT) {
+        return new GzipOutputStream($out, self::LEVELS[$method]);
+      }
+    };
+
+    self::$BZIP2= new class(2, 'BZIP2') extends Compression {
+      const LEVELS= [
+        Compression::FASTEST   => 1,
+        Compression::DEFAULT   => 4,
+        Compression::STRONGEST => 9,
+      ];
+
+      public function supported(): bool { return extension_loaded('bz2'); }
+      public function token(): string { return 'bzip2'; }
+      public function extension(): string { return '.bz2'; }
+      public function open($in) { return new Bzip2InputStream($in); }
+      public function create($out, $method= Compression::DEFAULT) {
+        return new Bzip2OutputStream($out, self::LEVELS[$method]);
+      }
+    };
+
+    self::$BROTLI= new class(3, 'BROTLI') extends Compression {
+      const LEVELS= [
+        Compression::FASTEST   => BROTLI_COMPRESS_LEVEL_MIN,
+        Compression::DEFAULT   => BROTLI_COMPRESS_LEVEL_DEFAULT,
+        Compression::STRONGEST => BROTLI_COMPRESS_LEVEL_MAX,
+      ];
+
+      public function supported(): bool { return extension_loaded('brotli'); }
+      public function token(): string { return 'br'; }
+      public function extension(): string { return '.br'; }
+      public function open($in) { return new BrotliInputStream($in); }
+      public function create($out, $method= Compression::DEFAULT) {
+        return new BrotliOutputStream($out, self::LEVELS[$method]);
+      }
+    };
+  }
+
+  /** Returns whether this compression algorithm is supported */
+  public abstract function supported(): bool;
+
+  /** Returns token for use with HTTP Content-Encoding */
+  public abstract function token(): string;
+
+  /** Returns common file extension including "." */
+  public abstract function extension(): string;
+
+  /**
+   * Returns compression algorithms supported in this setup, excluding
+   * the "NONE" algorithm. May return an empty list!
+   *
+   * @return self[]
+   */
+  public static function algorithms() {
+    $r= [];
+    foreach (self::values() as $compression) {
+      $compression->ordinal() && $compression->supported() && $r[]= $compression;
+    }
+    return $r;
+  }
+
+  /**
+   * Returns a compression for a given name. Accepts enumeration members
+   * in upper- and lowercase, common file extensions as well as the tokens
+   * used in HTTP Content-Encoding
+   *
+   * @throws  lang.IllegalArgumentException
+   */
+  public static function named(string $name): self {
+    switch (strtolower($name)) {
+      case 'none': case 'identity': return self::$NONE;
+      case 'gzip': case 'gz': case '.gz': return self::$GZIP;
+      case 'bzip2': case 'bz2': case '.bz2': return self::$BZIP2;
+      case 'brotli': case 'br': case '.br': return self::$BROTLI;
+      default: throw new IllegalArgumentException('Unknown compression algorithm "'.$name.'"');
+    }
+  }
+}

--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,112 +1,59 @@
 <?php namespace io\streams;
 
-use io\streams\compress\{
-  GzipInputStream,
-  GzipOutputStream,
-  Bzip2InputStream,
-  Bzip2OutputStream,
-  BrotliInputStream,
-  BrotliOutputStream
-};
-use lang\{Enum, IllegalArgumentException};
+use io\streams\compress\{Algorithm, Algorithms, Brotli, Bzip2, Gzip};
+use lang\IllegalArgumentException;
 
 /**
- * Compression algorithms enumeration
+ * Compression algorithms registry and lookup
  *
  * @see   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
  * @see   https://en.wikipedia.org/wiki/HTTP_compression#Content-Encoding_tokens
  * @test  io.streams.compress.unittest.CompressionTest
  */
-abstract class Compression extends Enum {
+abstract class Compression {
   const FASTEST   = 0;
   const DEFAULT   = 1;
   const STRONGEST = 2;
 
-  public static $NONE, $GZIP, $BZIP2, $BROTLI;
+  public static $NONE;
+  private static $algorithms;
 
   static function __static() {
-    self::$NONE= new class(0, 'NONE') extends Compression {
+    self::$NONE= new class() implements Algorithm {
       public function supported(): bool { return true; }
+      public function name(): string { return 'none'; }
       public function token(): string { return 'identity'; }
       public function extension(): string { return ''; }
-      public function open($in) { return $in; }
-      public function create($out, $method) { return $out; }
+      public function open(InputStream $in): InputStream { return $in; }
+      public function create(OutputStream $out, int $method): OutputStream { return $out; }
     };
 
-    self::$GZIP= new class(1, 'GZIP') extends Compression {
-      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 6, Compression::STRONGEST => 9];
-
-      public function supported(): bool { return extension_loaded('zlib'); }
-      public function token(): string { return 'gzip'; }
-      public function extension(): string { return '.gz'; }
-      public function open($in) { return new GzipInputStream($in); }
-      public function create($out, $method= Compression::DEFAULT) {
-        return new GzipOutputStream($out, self::LEVELS[$method]);
-      }
-    };
-
-    self::$BZIP2= new class(2, 'BZIP2') extends Compression {
-      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 4, Compression::STRONGEST => 9];
-
-      public function supported(): bool { return extension_loaded('bz2'); }
-      public function token(): string { return 'bzip2'; }
-      public function extension(): string { return '.bz2'; }
-      public function open($in) { return new Bzip2InputStream($in); }
-      public function create($out, $method= Compression::DEFAULT) {
-        return new Bzip2OutputStream($out, self::LEVELS[$method]);
-      }
-    };
-
-    self::$BROTLI= new class(3, 'BROTLI') extends Compression {
-      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 11, Compression::STRONGEST => 11];
-
-      public function supported(): bool { return extension_loaded('brotli'); }
-      public function token(): string { return 'br'; }
-      public function extension(): string { return '.br'; }
-      public function open($in) { return new BrotliInputStream($in); }
-      public function create($out, $method= Compression::DEFAULT) {
-        return new BrotliOutputStream($out, self::LEVELS[$method]);
-      }
-    };
+    // Register known algorithms included in this library
+    self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli());
   }
 
-  /** Returns whether this compression algorithm is supported */
-  public abstract function supported(): bool;
-
-  /** Returns token for use with HTTP Content-Encoding */
-  public abstract function token(): string;
-
-  /** Returns common file extension including "." */
-  public abstract function extension(): string;
-
   /**
-   * Returns compression algorithms supported in this setup, excluding
-   * the "NONE" algorithm. May return an empty list!
-   *
-   * @return self[]
+   * Returns registered compression algorithms, not including `Compression::$NONE`.
    */
-  public static function algorithms() {
-    $r= [];
-    foreach (self::values() as $compression) {
-      $compression->ordinal() && $compression->supported() && $r[]= $compression;
-    }
-    return $r;
+  public static function algorithms(): Algorithms {
+    return self::$algorithms;
   }
 
   /**
    * Returns a compression for a given name. Accepts enumeration members
    * in upper- and lowercase, common file extensions as well as the tokens
-   * used in HTTP Content-Encoding
+   * used in HTTP Content-Encoding.
    *
    * @throws  lang.IllegalArgumentException
    */
-  public static function named(string $name): self {
-    switch (strtolower($name)) {
-      case 'none': case 'identity': return self::$NONE;
-      case 'gzip': case 'gz': case '.gz': return self::$GZIP;
-      case 'bzip2': case 'bz2': case '.bz2': return self::$BZIP2;
-      case 'brotli': case 'br': case '.br': return self::$BROTLI;
-      default: throw new IllegalArgumentException('Unknown compression algorithm "'.$name.'"');
+  public static function named(string $name): Algorithm {
+    $lookup= strtolower($name);
+    if ('none' === $lookup || 'identity' === $lookup) {
+      return self::$NONE;
+    } else if ($algorithm= self::$algorithms->find($lookup)) {
+      return $algorithm;
     }
+
+    throw new IllegalArgumentException('Unknown compression algorithm "'.$name.'"');
   }
 }

--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -34,11 +34,7 @@ abstract class Compression extends Enum {
     };
 
     self::$GZIP= new class(1, 'GZIP') extends Compression {
-      const LEVELS= [
-        Compression::FASTEST   => 1,
-        Compression::DEFAULT   => 6,
-        Compression::STRONGEST => 9,
-      ];
+      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 6, Compression::STRONGEST => 9];
 
       public function supported(): bool { return extension_loaded('zlib'); }
       public function token(): string { return 'gzip'; }
@@ -50,11 +46,7 @@ abstract class Compression extends Enum {
     };
 
     self::$BZIP2= new class(2, 'BZIP2') extends Compression {
-      const LEVELS= [
-        Compression::FASTEST   => 1,
-        Compression::DEFAULT   => 4,
-        Compression::STRONGEST => 9,
-      ];
+      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 4, Compression::STRONGEST => 9];
 
       public function supported(): bool { return extension_loaded('bz2'); }
       public function token(): string { return 'bzip2'; }
@@ -66,11 +58,7 @@ abstract class Compression extends Enum {
     };
 
     self::$BROTLI= new class(3, 'BROTLI') extends Compression {
-      const LEVELS= [
-        Compression::FASTEST   => BROTLI_COMPRESS_LEVEL_MIN,
-        Compression::DEFAULT   => BROTLI_COMPRESS_LEVEL_DEFAULT,
-        Compression::STRONGEST => BROTLI_COMPRESS_LEVEL_MAX,
-      ];
+      const LEVELS= [Compression::FASTEST => 1, Compression::DEFAULT => 11, Compression::STRONGEST => 11];
 
       public function supported(): bool { return extension_loaded('brotli'); }
       public function token(): string { return 'br'; }

--- a/src/main/php/io/streams/compress/Algorithm.class.php
+++ b/src/main/php/io/streams/compress/Algorithm.class.php
@@ -1,0 +1,24 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream};
+
+interface Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool;
+
+  /** Returns the algorithm's name */
+  public function name(): string;
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string;
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string;
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream;
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $method): OutputStream;
+}

--- a/src/main/php/io/streams/compress/Algorithms.class.php
+++ b/src/main/php/io/streams/compress/Algorithms.class.php
@@ -1,0 +1,61 @@
+<?php namespace io\streams\compress;
+
+use IteratorAggregate, Traversable;
+
+/**
+ * Holds a list of compression algorithms
+ * 
+ * @test  io.streams.compress.unittest.AlgorithmsTest
+ */
+class Algorithms implements IteratorAggregate {
+  private $set= [], $lookup= [];
+
+  /**
+   * Adds the given algorithms. Overwrites algorithms with the same name
+   * if present!
+   */
+  public function add(Algorithm... $algorithms): self {
+    foreach ($algorithms as $algorithm) {
+      $name= $algorithm->name();
+      $this->set[$name]= $algorithm;
+      $this->lookup[$algorithm->token()]= $this->lookup[$algorithm->extension()]= $name;
+    }
+    return $this;
+  }
+
+  /**
+   * Finds a given algorithm by lookup, which may be either the name,
+   * the HTTP Content-Encoding token or the file extension. If nothing
+   * is found, `null` is returned.
+   * 
+   * @return ?io.streams.compress.Algorithm
+   */
+  public function find(string $lookup) {
+    return $this->set[$lookup] ?? (($name= $this->lookup[$lookup] ?? null) ? $this->set[$name] : null);
+  }
+
+  /**
+   * Removes the given algorithm. Returns `false` if the algorithm was
+   * not included in this set.
+   */
+  public function remove(Algorithm $algorithm): bool {
+    $name= $algorithm->name();
+    if (!isset($this->set[$name])) return false;
+
+    unset($this->lookup[$this->set[$name]->token()], $this->lookup[$this->set[$name]->extension()]);
+    unset($this->set[$name]);
+    return true;
+  }
+
+  /** Iterates over algorithms, name => instance */
+  public function getIterator(): Traversable {
+    yield from $this->set;
+  }
+
+  /** Iterates over supported algorithms, name => instance */
+  public function supported(): Traversable {
+    foreach ($this->set as $name => $algorithm) {
+      if ($algorithm->supported()) yield $name => $algorithm;
+    }
+  }
+}

--- a/src/main/php/io/streams/compress/Brotli.class.php
+++ b/src/main/php/io/streams/compress/Brotli.class.php
@@ -25,6 +25,6 @@ class Brotli implements Algorithm {
   public function create(OutputStream $out, int $method): OutputStream {
     static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 11, Compression::STRONGEST => 11];
 
-    return new BrotlOutputStream($in, $levels[$method]);
+    return new BrotliOutputStream($out, $levels[$method]);
   }
 }

--- a/src/main/php/io/streams/compress/Brotli.class.php
+++ b/src/main/php/io/streams/compress/Brotli.class.php
@@ -1,0 +1,30 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream, Compression};
+
+class Brotli implements Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return extension_loaded('brotli'); }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'brotli'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'br'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return '.br'; }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+    return new BrotliInputStream($in);
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $method): OutputStream {
+    static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 11, Compression::STRONGEST => 11];
+
+    return new BrotlOutputStream($in, $levels[$method]);
+  }
+}

--- a/src/main/php/io/streams/compress/Bzip2.class.php
+++ b/src/main/php/io/streams/compress/Bzip2.class.php
@@ -25,6 +25,6 @@ class Bzip2 implements Algorithm {
   public function create(OutputStream $out, int $method): OutputStream {
     static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 4, Compression::STRONGEST => 9];
 
-    return new Bzip2OutputStream($in, $levels[$method]);
+    return new Bzip2OutputStream($out, $levels[$method]);
   }
 }

--- a/src/main/php/io/streams/compress/Bzip2.class.php
+++ b/src/main/php/io/streams/compress/Bzip2.class.php
@@ -1,0 +1,30 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream, Compression};
+
+class Bzip2 implements Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return extension_loaded('bzip2'); }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'bzip2'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'bzip2'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return '.bz2'; }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+    return new Bzip2InputStream($in);
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $method): OutputStream {
+    static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 4, Compression::STRONGEST => 9];
+
+    return new Bzip2OutputStream($in, $levels[$method]);
+  }
+}

--- a/src/main/php/io/streams/compress/Gzip.class.php
+++ b/src/main/php/io/streams/compress/Gzip.class.php
@@ -1,0 +1,30 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream, Compression};
+
+class Gzip implements Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return extension_loaded('zlib'); }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'gzip'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'gzip'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return '.gz'; }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+    return new GzipInputStream($in);
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $method): OutputStream {
+    static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 6, Compression::STRONGEST => 9];
+
+    return new GzipOutputStream($in, $levels[$method]);
+  }
+}

--- a/src/main/php/io/streams/compress/Gzip.class.php
+++ b/src/main/php/io/streams/compress/Gzip.class.php
@@ -25,6 +25,6 @@ class Gzip implements Algorithm {
   public function create(OutputStream $out, int $method): OutputStream {
     static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 6, Compression::STRONGEST => 9];
 
-    return new GzipOutputStream($in, $levels[$method]);
+    return new GzipOutputStream($out, $levels[$method]);
   }
 }

--- a/src/main/php/io/streams/compress/None.class.php
+++ b/src/main/php/io/streams/compress/None.class.php
@@ -1,0 +1,28 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream};
+
+class None implements Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return true; }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'none'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'identity'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return ''; }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+    return $in;
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $method): OutputStream {
+    return $out;
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
@@ -1,0 +1,94 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\compress\{Algorithm, Algorithms};
+use io\streams\{InputStream, OutputStream};
+use unittest\{Assert, Before, Test, Values};
+
+class AlgorithmsTest {
+  private $supported, $unsupported;
+
+  #[Before]
+  public function algorithm() {
+    $this->supported= new class() implements Algorithm {
+      public function supported(): bool { return true; }
+      public function name(): string { return 'test'; }
+      public function token(): string { return 'x-test'; }
+      public function extension(): string { return '.test'; }
+      public function open(InputStream $in): InputStream { return $in; }
+      public function create(OutputStream $out, int $method): OutputStream { return $out; }
+    };
+    $this->unsupported= new class() implements Algorithm {
+      public function supported(): bool { return false; }
+      public function name(): string { return 'lzw'; }
+      public function token(): string { return 'compress'; }
+      public function extension(): string { return '.lz'; }
+      public function open(InputStream $in): InputStream { return $in; }
+      public function create(OutputStream $out, int $method): OutputStream { return $out; }
+    };
+  }
+
+  #[Test]
+  public function can_create() {
+    new Algorithms();
+  }
+
+  #[Test]
+  public function add_returns_instance() {
+    $fixture= new Algorithms();
+    Assert::equals($fixture, $fixture->add($this->supported));
+  }
+
+  #[Test]
+  public function find_on_empty() {
+    Assert::null((new Algorithms())->find('test'));
+  }
+
+  #[Test, Values(['test', 'x-test', '.test'])]
+  public function find_by($lookup) {
+    Assert::equals($this->supported, (new Algorithms())->add($this->supported)->find($lookup));
+  }
+
+  #[Test]
+  public function find_non_existant() {
+    Assert::null((new Algorithms())->add($this->supported)->find('non-existant'));
+  }
+
+  #[Test]
+  public function iterate() {
+    Assert::equals(
+      ['test' => $this->supported, 'lzw' => $this->unsupported],
+      iterator_to_array((new Algorithms())->add($this->supported, $this->unsupported))
+    );
+  }
+
+  #[Test]
+  public function supported() {
+    Assert::equals(
+      ['test'=> $this->supported],
+      iterator_to_array((new Algorithms())->add($this->supported, $this->unsupported)->supported())
+    );
+  }
+
+  #[Test]
+  public function remove_existant() {
+    Assert::true((new Algorithms())->add($this->supported)->remove($this->supported));
+  }
+
+  #[Test]
+  public function remove_non_existant() {
+    Assert::false((new Algorithms())->add($this->supported)->remove($this->unsupported));
+  }
+
+  #[Test]
+  public function remove_on_empty() {
+    Assert::false((new Algorithms())->remove($this->supported));
+  }
+
+  #[Test, Values(['test', 'x-test', '.test'])]
+  public function find_after_removing($lookup) {
+    $fixture= (new Algorithms())->add($this->supported);
+    $fixture->remove($this->supported);
+
+    Assert::null($fixture->find($lookup));
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -1,0 +1,61 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\Compression;
+use lang\IllegalArgumentException;
+use unittest\{Assert, Test, Values};
+
+class CompressionTest {
+
+  /** @return iterable */
+  private function names() {
+
+    // Member names
+    yield ['none', Compression::$NONE];
+    yield ['gzip', Compression::$GZIP];
+    yield ['bzip2', Compression::$BZIP2];
+    yield ['brotli', Compression::$BROTLI];
+    yield ['NONE', Compression::$NONE];
+    yield ['GZIP', Compression::$GZIP];
+    yield ['BZIP2', Compression::$BZIP2];
+    yield ['BROTLI', Compression::$BROTLI];
+
+    // Short names used in file extensions or HTTP Content-Encoding
+    yield ['identity', Compression::$NONE];
+    yield ['gz', Compression::$GZIP];
+    yield ['bz2', Compression::$BZIP2];
+    yield ['br', Compression::$BROTLI];
+    yield ['.gz', Compression::$GZIP];
+    yield ['.bz2', Compression::$BZIP2];
+    yield ['.br', Compression::$BROTLI];
+  }
+
+  #[Test]
+  public function algorithms() {
+    Assert::instance('io.streams.Compression[]', Compression::algorithms());
+  }
+
+  #[Test, Values('names')]
+  public function named($name, $expected) {
+    Assert::equals($expected, Compression::named($name));
+  }
+
+  #[Test, Values(map: ['none' => 'core', 'gzip' => 'zlib', 'bzip2' => 'bz2', 'brotli' => 'brotli'])]
+  public function supported($compression, $extension) {
+    Assert::equals(extension_loaded($extension), Compression::named($compression)->supported());
+  }
+
+  #[Test, Values(map: ['none' => 'identity', 'gzip' => 'gzip', 'bzip2' => 'bzip2', 'brotli' => 'br'])]
+  public function token($compression, $expected) {
+    Assert::equals($expected, Compression::named($compression)->token());
+  }
+
+  #[Test, Values(map: ['none' => '', 'gzip' => '.gz', 'bzip2' => '.bz2', 'brotli' => '.br'])]
+  public function extension($compression, $expected) {
+    Assert::equals($expected, Compression::named($compression)->extension());
+  }
+
+  #[Test, Values(['', 'test']), Expect(IllegalArgumentException::class)]
+  public function unknown($name) {
+    Compression::named($name);
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -2,44 +2,56 @@
 
 use io\streams\Compression;
 use lang\IllegalArgumentException;
-use unittest\{Assert, Test, Values};
+use unittest\{Assert, Before, Test, Values};
 
 class CompressionTest {
 
   /** @return iterable */
   private function names() {
 
-    // Member names
-    yield ['none', Compression::$NONE];
-    yield ['gzip', Compression::$GZIP];
-    yield ['bzip2', Compression::$BZIP2];
-    yield ['brotli', Compression::$BROTLI];
-    yield ['NONE', Compression::$NONE];
-    yield ['GZIP', Compression::$GZIP];
-    yield ['BZIP2', Compression::$BZIP2];
-    yield ['BROTLI', Compression::$BROTLI];
+    // Special member
+    yield ['none', 'none'];
+    yield ['identity', 'none'];
+    yield ['NONE', 'none'];
+    yield ['IDENTITY', 'none'];
 
-    // Short names used in file extensions or HTTP Content-Encoding
-    yield ['identity', Compression::$NONE];
-    yield ['gz', Compression::$GZIP];
-    yield ['bz2', Compression::$BZIP2];
-    yield ['br', Compression::$BROTLI];
-    yield ['.gz', Compression::$GZIP];
-    yield ['.bz2', Compression::$BZIP2];
-    yield ['.br', Compression::$BROTLI];
+    // Included in this library
+    yield ['gzip', 'gzip'];
+    yield ['bzip2', 'bzip2'];
+    yield ['brotli', 'brotli'];
+    yield ['GZIP', 'gzip'];
+    yield ['BZIP2', 'bzip2'];
+    yield ['BROTLI', 'brotli'];
+
+    // File extensions
+    yield ['.gz', 'gzip'];
+    yield ['.bz2', 'bzip2'];
+    yield ['.br', 'brotli'];
+
+    // HTTP Content-Encoding aliases
+    yield ['br', 'brotli'];    
   }
 
   #[Test]
-  public function algorithms() {
-    Assert::instance('io.streams.Compression[]', Compression::algorithms());
+  public function enumerating_included_algorithms() {
+    $names= [];
+    foreach (Compression::algorithms() as $name => $algorithm) {
+      $names[]= $name;
+    }
+    Assert::equals(['gzip', 'bzip2', 'brotli'], $names);
+  }
+
+  #[Test]
+  public function supported_algorithms() {
+    Assert::instance('[:io.streams.compress.Algorithm]', iterator_to_array(Compression::algorithms()->supported()));
   }
 
   #[Test, Values('names')]
   public function named($name, $expected) {
-    Assert::equals($expected, Compression::named($name));
+    Assert::equals($expected, Compression::named($name)->name());
   }
 
-  #[Test, Values(map: ['none' => 'core', 'gzip' => 'zlib', 'bzip2' => 'bz2', 'brotli' => 'brotli'])]
+  #[Test, Values(map: ['none' => 'core', 'gzip' => 'zlib', 'bzip2' => 'bzip2', 'brotli' => 'brotli'])]
   public function supported($compression, $extension) {
     Assert::equals(extension_loaded($extension), Compression::named($compression)->supported());
   }


### PR DESCRIPTION
Adds a class `io.streams.Compression` which serves as an entry point to access compression algorithms supported in this setup, by name, HTTP Content-Encoding token or file extension

## Example

The following fetches a given URL, handling compression as explained in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#examples. *For sake of readability, multiple content-encodings are ignored*.

```php
use io\streams\Compression;
use peer\http\HttpConnection;

// Compile list of supported compression algorithms, e.g. "gzip, br"
$supported= [];
foreach (Compression::algorithms()->supported() as $compression) {
  $supported[]= $compression->token();
}

// Make request, sending supported content encodings via Accept-Encoding
$conn= new HttpConnection($argv[1]);
$res= $conn->get(null, ['Accept-Encoding' => implode(', ', $supported)]);

// Handle Content-Encoding header
if ($encoding= $res->header('Content-Encoding')) {
  $compression= Compression::named($encoding[0]);

  echo "== Using {$compression->name()} ==\n";
  $in= $compression->open($res->in());
} else {
  echo "== Uncompressed ==\n";
  $in= $res->in();
}

// Write contents to output
while ($in->available()) {
  echo $in->read();
}
$in->close();
```
