### PR TITLE
Make Compression::named() raise exceptions for unsupported algorithms

### DIFF
--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\streams;
 
 use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip};
-use lang\IllegalArgumentException;
+use lang\MethodNotImplementedException;
 
 /**
  * Compression algorithms registry and lookup
@@ -37,16 +37,16 @@ abstract class Compression {
    * in upper- and lowercase, common file extensions as well as the tokens
    * used in HTTP Content-Encoding.
    *
-   * @throws  lang.IllegalArgumentException
+   * @throws  lang.IllegalArgumentException when unknown
+   * @throws  lang.MethodNotImplementedException when unsupported
    */
   public static function named(string $name): Algorithm {
     $lookup= strtolower($name);
-    if ('none' === $lookup || 'identity' === $lookup) {
-      return self::$NONE;
-    } else if ($algorithm= self::$algorithms->find($lookup)) {
-      return $algorithm;
-    }
+    if ('none' === $lookup || 'identity' === $lookup) return self::$NONE;
 
-    throw new IllegalArgumentException('Unknown compression algorithm "'.$name.'"');
+    $algorithm= self::$algorithms->named($lookup);
+    if ($algorithm->supported()) return $algorithm;
+
+    throw new MethodNotImplementedException('Unsupported compression algorithm', $name);
   }
 }

--- a/src/main/php/io/streams/compress/Algorithms.class.php
+++ b/src/main/php/io/streams/compress/Algorithms.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\streams\compress;
 
 use IteratorAggregate, Traversable;
-use lang\Value;
+use lang\{Value, IllegalArgumentException};
 use util\Objects;
 
 /**
@@ -34,6 +34,17 @@ class Algorithms implements IteratorAggregate, Value {
    */
   public function find(string $lookup) {
     return $this->set[$lookup] ?? (($name= $this->lookup[$lookup] ?? null) ? $this->set[$name] : null);
+  }
+
+  /**
+   * Like find, but raises an exception if nothing is found.
+   *
+   * @throws  lang.IllegalArgumentException
+   */
+  public function named(string $lookup): Algorithm {
+    if ($algorithm= $this->find($lookup)) return $algorithm;
+
+    throw new IllegalArgumentException('Unknown compression algorithm "'.$lookup.'"');
   }
 
   /**


### PR DESCRIPTION

## Current behavior
If *bzip2* extension is not loaded:

```bash
❯ XP_RT=7.0 xp -w '\io\streams\Compression::named("bzip2")->open(\util\cmd\Console::$in->stream())'
Uncaught exception: Exception io.IOException (Could not append stream filter)
  at <main>::stream_filter_append() [line 23 of Bzip2InputStream.class.php] stream_filter_append(): unable to locate filter "bzip2.decompress"
  at io.streams.compress.Bzip2InputStream::__construct(io.streams.ConsoleInputStream{}) [line 21 of Bzip2.class.php]
  at io.streams.compress.Bzip2::open(io.streams.ConsoleInputStream{}) [line 1 of (command line argument)]
  ...
```

If *brotli* extension is not loaded:

```bash
❯ XP_RT=7.0 xp -w '\io\streams\Compression::named("brotli")->open(\util\cmd\Console::$in->stream())'
Uncaught exception: Exception lang.Error (Call to undefined function io\streams\compress\brotli_uncompress_init())
  at <native>::Error(0, (0x47)'Call to undefined function io\streams\compress\brotli_uncompress') [line 22 of BrotliInputStream.class.php]
  at io.streams.compress.BrotliInputStream::__construct(io.streams.ConsoleInputStream{}) [line 21 of Brotli.class.php]
  at io.streams.compress.Brotli::open(io.streams.ConsoleInputStream{}) [line 1 of (command line argument)]
  ...
```

## New behavior

Now raises a *lang.MethodNotImplementedException* in both cases, meaning we can catch and handle this in a dedicated way:

```bash
❯ XP_RT=7.0 xp -w '\io\streams\Compression::named("bzip2")->open(\util\cmd\Console::$in->stream())'
Uncaught exception: Exception lang.MethodNotImplementedException (method bzip2(): Unsupported compression algorithm)
  at io.streams.Compression::named((0x5)'bzip2') [line 1 of (command line argument)]
  ...
```

## Looking up unsupported algorithms

If you want to look up unsupported algorithms without having exceptions raised, use the following:

```php
use io\streams\Compression;

// Raises an exception if ext/bzip2 is not loaded
$algorithm= Compression::named('bzip2');

// Returns the Bzip2 algorithm instance in any case
// Use $algorithm->supported() to check whether ext/bzip2 is loaded.
$algorithm= Compression::algorithms()->named('bzip2');
```