### PR TITLE
Add Algorithms::accept()

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,12 @@ use io\streams\Compression;
 use peer\http\HttpConnection;
 
 // Compile list of supported compression algorithms, e.g. "gzip, br"
-$supported= [];
-foreach (Compression::algorithms()->supported() as $compression) {
-  $supported[]= $compression->token();
-}
-echo "== Sending ", implode(', ', $supported), " ==\n";
+$accept= Compression::algorithms()->accept();
+echo "== Sending {$accept} ==\n";
 
 // Make request, sending supported content encodings via Accept-Encoding
 $conn= new HttpConnection($argv[1]);
-$res= $conn->get(null, ['Accept-Encoding' => implode(', ', $supported)]);
+$res= $conn->get(null, ['Accept-Encoding' => $accept]);
 
 // Handle Content-Encoding header
 if ($encoding= $res->header('Content-Encoding')) {

--- a/src/main/php/io/streams/compress/Algorithms.class.php
+++ b/src/main/php/io/streams/compress/Algorithms.class.php
@@ -72,6 +72,15 @@ class Algorithms implements IteratorAggregate, Value {
     }
   }
 
+  /** Returns HTTP accept header for supported algorithms */
+  public function accept(): string {
+    $accept= '';
+    foreach ($this->set as $algorithm) {
+      if ($algorithm->supported()) $accept.= ", {$algorithm->token()}";
+    }
+    return substr($accept, 2);
+  }
+
   /** @return string */
   public function hashCode() {
     return 'CA'.implode('&', array_keys($this->set));

--- a/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
@@ -5,7 +5,7 @@ use io\streams\{Compression, InputStream, OutputStream};
 use test\{Assert, Before, Test, Values};
 
 class AlgorithmsTest {
-  private $supported, $unsupported;
+  private $supported, $additional, $unsupported;
 
   #[Before]
   public function algorithm() {
@@ -14,6 +14,15 @@ class AlgorithmsTest {
       public function name(): string { return 'test'; }
       public function token(): string { return 'x-test'; }
       public function extension(): string { return '.test'; }
+      public function level(int $select): int { return $select; }
+      public function open(InputStream $in): InputStream { return $in; }
+      public function create(OutputStream $out, int $method= Compression::DEFAULT): OutputStream { return $out; }
+    };
+    $this->additional= new class() extends Algorithm {
+      public function supported(): bool { return true; }
+      public function name(): string { return 'add'; }
+      public function token(): string { return 'x-add'; }
+      public function extension(): string { return '.add'; }
       public function level(int $select): int { return $select; }
       public function open(InputStream $in): InputStream { return $in; }
       public function create(OutputStream $out, int $method= Compression::DEFAULT): OutputStream { return $out; }
@@ -66,8 +75,16 @@ class AlgorithmsTest {
   #[Test]
   public function supported() {
     Assert::equals(
-      ['test'=> $this->supported],
+      ['test' => $this->supported],
       iterator_to_array((new Algorithms())->add($this->supported, $this->unsupported)->supported())
+    );
+  }
+
+  #[Test]
+  public function accept() {
+    Assert::equals(
+      'x-test, x-add',
+      (new Algorithms())->add($this->supported, $this->additional, $this->unsupported)->accept()
     );
   }
 


### PR DESCRIPTION
This pull request adds an *accept()* method to the *Algorithms* class.

```php
// Before
$tokens= [];
foreach (Compression::algorithms()->supported() as $algorithm) {
  $tokens[]= $algorithm->token();
}
$accept= implode(', ', $tokens);

// After
$accept= Compression::algorithms()->accept();
```