### PR TITLE
Add Compression::select() for easy negotiation

### DIFF
--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -49,4 +49,22 @@ abstract class Compression {
 
     throw new MethodNotImplementedException('Unsupported compression algorithm', $name);
   }
+
+  /**
+   * Selects a compression for a given list of preferred algorithms. Returns
+   * the first supported one, or NULL if none in the given list is supported.
+   *
+   * @param   iterable $preferred
+   * @return  ?io.streams.compress.Algorithm
+   */
+  public static function select($preferred) {
+    foreach ($preferred as $name) {
+      $lookup= strtolower($name);
+      if ('none' === $lookup || 'identity' === $lookup) return self::$NONE;
+
+      $algorithm= self::$algorithms->find($lookup);
+      if ($algorithm && $algorithm->supported()) return $algorithm;
+    }
+    return null;
+  }
 }

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -56,6 +56,26 @@ class CompressionTest {
     Assert::equals('gzip', Compression::named($name)->name());
   }
 
+  #[Test, Runtime(extensions: ['zlib'])]
+  public function select_gzip() {
+    Assert::equals('gzip', Compression::select(['gzip', 'identity'])->name());
+  }
+
+  #[Test]
+  public function select_no_preference() {
+    Assert::null(Compression::select([]));
+  }
+
+  #[Test]
+  public function select_just_unsupported() {
+    Assert::null(Compression::select(['unsupported']));
+  }
+
+  #[Test]
+  public function select_ignores_unsupported() {
+    Assert::equals(Compression::$NONE, Compression::select(['unsupported', 'identity']));
+  }
+
   #[Test, Values(from: 'names')]
   public function algorithms_named($name, $expected) {
     Assert::equals($expected, Compression::algorithms()->named($name)->name());


### PR DESCRIPTION
Example:

```php
use web\Headers;

$preference= Headers::qfactors()->parse($req->header('Accept-Encoding'));
$compress= Compression::select(array_keys(array_filter($preference)));
```