### PR TITLE
Add io.streams.compress.Deflate and register it in algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ io.streams.compress.Algorithms@{
   io.streams.compress.Gzip(token: gzip, extension: .gz, supported: true, levels: 1..9)
   io.streams.compress.Bzip2(token: bzip2, extension: .bz2, supported: false, levels: 1..9)
   io.streams.compress.Brotli(token: br, extension: .br, supported: true, levels: 1..11)
+  io.streams.compress.Deflate(token: deflate, extension: (none), supported: true, levels: 1..9)
 }
 ```
 

--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip};
+use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip, Deflate};
 use lang\MethodNotImplementedException;
 
 /**
@@ -22,7 +22,7 @@ abstract class Compression {
     self::$NONE= new None();
 
     // Register known algorithms included in this library
-    self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli());
+    self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli(), new Deflate());
   }
 
   /**

--- a/src/main/php/io/streams/compress/Algorithms.class.php
+++ b/src/main/php/io/streams/compress/Algorithms.class.php
@@ -20,7 +20,8 @@ class Algorithms implements IteratorAggregate, Value {
     foreach ($algorithms as $algorithm) {
       $name= $algorithm->name();
       $this->set[$name]= $algorithm;
-      $this->lookup[$algorithm->token()]= $this->lookup[$algorithm->extension()]= $name;
+      $this->lookup[$algorithm->token()]= $name;
+      if ('' !== ($ext= $algorithm->extension())) $this->lookup[$ext]= $name;
     }
     return $this;
   }

--- a/src/main/php/io/streams/compress/Deflate.class.php
+++ b/src/main/php/io/streams/compress/Deflate.class.php
@@ -1,0 +1,34 @@
+<?php namespace io\streams\compress;
+
+use io\streams\{InputStream, OutputStream, Compression};
+
+class Deflate extends Algorithm {
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return extension_loaded('zlib'); }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'deflate'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'deflate'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return ''; }
+
+  /** Maps fastest, default and strongest levels */
+  public function level(int $select): int {
+    static $levels= [Compression::FASTEST => 1, Compression::DEFAULT => 6, Compression::STRONGEST => 9];
+    return $levels[$select] ?? $select;
+  }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+    return new InflatingInputStream($in);
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
+    return new DeflatingOutputStream($out, $this->level($level));
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -38,7 +38,7 @@ class CompressionTest {
     foreach (Compression::algorithms() as $name => $algorithm) {
       $names[]= $name;
     }
-    Assert::equals(['gzip', 'bzip2', 'brotli'], $names);
+    Assert::equals(['gzip', 'bzip2', 'brotli', 'deflate'], $names);
   }
 
   #[Test]

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -14,6 +14,7 @@ class CompressionTest {
     yield ['gzip', 'gzip'];
     yield ['bzip2', 'bzip2'];
     yield ['brotli', 'brotli'];
+    yield ['deflate', 'deflate'];
 
     // File extensions
     yield ['.gz', 'gzip'];
@@ -61,12 +62,12 @@ class CompressionTest {
     Assert::equals($expected, Compression::algorithms()->named($name)->name());
   }
 
-  #[Test, Values([['gzip', 'zlib'], ['bzip2', 'bzip2'], ['brotli', 'brotli']])]
+  #[Test, Values([['gzip', 'zlib'], ['bzip2', 'bzip2'], ['brotli', 'brotli'], ['deflate', 'zlib']])]
   public function supported($compression, $extension) {
     Assert::equals(extension_loaded($extension), Compression::algorithms()->named($compression)->supported());
   }
 
-  #[Test, Values([['gzip', 'gzip'], ['bzip2', 'bzip2'], ['brotli', 'br']])]
+  #[Test, Values([['gzip', 'gzip'], ['bzip2', 'bzip2'], ['brotli', 'br'], ['deflate', 'deflate']])]
   public function token($compression, $expected) {
     Assert::equals($expected, Compression::algorithms()->named($compression)->token());
   }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding, where this is listed as one of the example values