### PR TITLE
Implement snappy compression in userland code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compression streams
 [![Supports PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/compression/version.svg)](https://packagist.org/packages/xp-forge/compression)
 
-Compressing output and decompressing input streams including GZip, BZip2, Brotli, ZStandard and Snappy.
+Compressing output and decompressing input streams including GZip, BZip2, Brotli, Snappy and ZStandard.
 
 Examples
 --------
@@ -41,10 +41,10 @@ Dependencies
 ------------
 Compression algorithms might require a specific PHP extension:
 
-* **Snappy** - no dependencies, implemented in userland
 * **GZip** - requires PHP's ["zlib" extension](https://www.php.net/zlib)
 * **Bzip2** - requires PHP's ["bzip2" extension](https://www.php.net/bzip2)
 * **Brotli** - requires https://github.com/kjdev/php-ext-brotli
+* **Snappy** - *no dependencies, implemented in userland*
 * **ZStandard** - requires https://github.com/kjdev/php-ext-zstd
 
 Accessing these algorithms can be done via the `Compression` API:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compression streams
 [![Supports PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/compression/version.svg)](https://packagist.org/packages/xp-forge/compression)
 
-Compressing output and decompressing input streams including GZip, BZip2 and Brotli.
+Compressing output and decompressing input streams including GZip, BZip2 and Brotli and Snappy.
 
 Examples
 --------
@@ -39,8 +39,9 @@ $out->close();
 
 Dependencies
 ------------
-Compression algorithms are implemented in C and thus require a specific PHP extension:
+Compression algorithms might require a specific PHP extension:
 
+* **Snappy** - no dependencies, implemented in userland
 * **GZip** - requires PHP's ["zlib" extension](https://www.php.net/zlib)
 * **Bzip2** - requires PHP's ["bzip2" extension](https://www.php.net/bzip2)
 * **Brotli** - requires https://github.com/kjdev/php-ext-brotli

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ io.streams.compress.Algorithms@{
   io.streams.compress.Gzip(token: gzip, extension: .gz, supported: true, levels: 1..9)
   io.streams.compress.Bzip2(token: bzip2, extension: .bz2, supported: false, levels: 1..9)
   io.streams.compress.Brotli(token: br, extension: .br, supported: true, levels: 1..11)
+  io.streams.compress.Snappy(token: snappy, extension: .sn, supported: true, levels: 0..0)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ $in->close();
 See also
 --------
 * The PHP RFC [Modern Compression](https://wiki.php.net/rfc/modern_compression) suggests adding *zstd* and *brotli* into PHP.
+* Snappy *does not aim for maximum compression, or compatibility with any other compression library; instead, it aims for very high speeds and reasonable compression*, quoting [its Wikipedia page](https://en.wikipedia.org/wiki/Snappy_(compression))

--- a/src/main/php/io/streams/Compression.class.php
+++ b/src/main/php/io/streams/Compression.class.php
@@ -1,6 +1,6 @@
 <?php namespace io\streams;
 
-use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip};
+use io\streams\compress\{Algorithm, Algorithms, None, Brotli, Bzip2, Gzip, Snappy};
 use lang\MethodNotImplementedException;
 
 /**
@@ -22,7 +22,7 @@ abstract class Compression {
     self::$NONE= new None();
 
     // Register known algorithms included in this library
-    self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli());
+    self::$algorithms= (new Algorithms())->add(new Gzip(), new Bzip2(), new Brotli(), new Snappy());
   }
 
   /**

--- a/src/main/php/io/streams/compress/BufferedInputStream.class.php
+++ b/src/main/php/io/streams/compress/BufferedInputStream.class.php
@@ -1,0 +1,78 @@
+<?php namespace io\streams\compress;
+
+use io\streams\InputStream;
+use lang\IllegalArgumentException;
+
+/** @test io.streams.compress.unittest.BufferedInputStreamTest */
+class BufferedInputStream implements InputStream {
+  private $in, $decompress;
+  private $buffer= null, $position= 0;
+
+  /**
+   * Creates a new decompressing input stream
+   *
+   * @param  io.streams.InputStream $in The stream to read from
+   * @param  io.streams.compress.Algorithm|function(string): string $decompress
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(InputStream $in, $decompress) {
+    if ($decompress instanceof Algorithm) {
+      $this->decompress= [$decompress, 'decompress'];
+    } else if (is_callable($decompress)) {
+      $this->decompress= $decompress;
+    } else {
+      throw new IllegalArgumentException('Expected an Algorithm or a callable, have '.typeof($decompress));
+    }
+    $this->in= $in;
+  }
+
+  /** @return string */
+  private function buffer() {
+    if (null === $this->buffer) {
+      $compressed= '';
+      while ($this->in->available()) {
+        $compressed.= $this->in->read();
+      }
+
+      $this->buffer= ($this->decompress)($compressed);
+    }
+    return $this->buffer;
+  }
+
+  /**
+   * Read a string
+   *
+   * @param   int limit default 8192
+   * @return  string
+   */
+  public function read($limit= 8192) {
+    $chunk= substr($this->buffer(), $this->position, $limit);
+    $this->position+= strlen($chunk);
+    return $chunk;
+  }
+
+  /**
+   * Returns the number of bytes that can be read from this stream 
+   * without blocking.
+   *
+   * @return int
+   */
+  public function available() {
+    return strlen($this->buffer()) - $this->position;
+  }
+
+  /**
+   * Close this buffer.
+   *
+   * @return void
+   */
+  public function close() {
+    $this->buffer= null;
+    $this->in->close();
+  }
+
+  /** Ensures input stream is closed */
+  public function __destruct() {
+    $this->close();
+  }
+}

--- a/src/main/php/io/streams/compress/BufferedOutputStream.class.php
+++ b/src/main/php/io/streams/compress/BufferedOutputStream.class.php
@@ -57,5 +57,11 @@ class BufferedOutputStream implements OutputStream {
       $this->out->write(($this->compress)($this->buffer));
       $this->buffer= null;
     }
+    $this->out->close();
+  }
+
+  /** Ensures output stream is closed */
+  public function __destruct() {
+    $this->close();
   }
 }

--- a/src/main/php/io/streams/compress/BufferedOutputStream.class.php
+++ b/src/main/php/io/streams/compress/BufferedOutputStream.class.php
@@ -1,0 +1,61 @@
+<?php namespace io\streams\compress;
+
+use io\streams\OutputStream;
+use lang\IllegalArgumentException;
+
+/** @test io.streams.compress.unittest.BufferedOutputStreamTest */
+class BufferedOutputStream implements OutputStream {
+  private $out, $compress;
+  private $buffer= '';
+
+  /**
+   * Creates a new compressing output stream
+   *
+   * @param  io.streams.OutputStream $out The stream to write to
+   * @param  io.streams.compress.Algorithm|function(string): string $compress
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(OutputStream $out, $compress) {
+    if ($compress instanceof Algorithm) {
+      $this->compress= [$compress, 'compress'];
+    } else if (is_callable($compress)) {
+      $this->compress= $compress;
+    } else {
+      throw new IllegalArgumentException('Expected an Algorithm or a callable, have '.typeof($compress));
+    }
+    $this->out= $out;
+  }
+
+  /**
+   * Write a string
+   *
+   * @param  var $arg
+   * @return void
+   */
+  public function write($arg) {
+    $this->buffer.= $arg;
+  }
+
+  /**
+   * Flush this buffer
+   *
+   * @return void
+   */
+  public function flush() {
+    // NOOP
+  }
+
+  /**
+   * Closes this object. May be called more than once, which may
+   * not fail - that is, if the object is already closed, this 
+   * method should have no effect.
+   *
+   * @return void
+   */
+  public function close() {
+    if (null !== $this->buffer) {
+      $this->out->write(($this->compress)($this->buffer));
+      $this->buffer= null;
+    }
+  }
+}

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -61,12 +61,14 @@ class Snappy extends Algorithm {
     $out.= chr($l);
 
     // Compare 4-byte offsets in data at offsets a and b
-    $equals32= fn($a, $b) => (
-      $data[$a] === $data[$b] &&
-      $data[$a + 1] === $data[$b + 1] &&
-      $data[$a + 2] === $data[$b + 2] &&
-      $data[$a + 3] === $data[$b + 3]
-    );
+    $equals32= function($a, $b) use(&$data) {
+      return (
+        $data[$a] === $data[$b] &&
+        $data[$a + 1] === $data[$b + 1] &&
+        $data[$a + 2] === $data[$b + 2] &&
+        $data[$a + 3] === $data[$b + 3]
+      );
+    };
 
     for ($emit= $pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {
       $fragment= min($length - $pos, self::BLOCK_SIZE);

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -96,7 +96,7 @@ class Snappy extends Algorithm {
           $hash= $next;
           $forward+= ($skip & 0xffffffff) >> 5;
           $skip++;
-          if ($pos > $limit) goto emit;
+          if ($pos > $limit || $forward > $limit) goto emit;
 
           $next= ((unpack('V', $data, $forward)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
           $candidate= $start + $hashtable[$hash];

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -54,8 +54,10 @@ class Snappy extends Algorithm {
   public static function copy(int $i, int $l): string {
     if ($l < 12 && $i < 2048) {
       return pack('CC', 1 + (($l - 4) << 2) + ((($i & 0xffffffff) >> 8) << 5), $i & 0xff);
-    } else {
+    } else if ($i < 65536) {
       return pack('CCC', 2 + (($l - 1) << 2), $i & 0xff, ($i & 0xffffffff) >> 8);
+    } else {
+      return pack('CV', 3 + (($l - 1) << 2), $i & 0xffffffff);
     }
   }
 

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -167,9 +167,11 @@ class Snappy extends Algorithm {
           if (60 === $l) {
             if ($pos + 1 >= $limit) throw new IOException('Not enough input, expected 1');
             $l= unpack('C', $bytes, $pos)[1];
+            $pos++;
           } else if (61 === $l) {
             if ($pos + 2 >= $limit) throw new IOException('Not enough input, expected 2');
             $l= unpack('v', $bytes, $pos)[1];
+            $pos+= 2;
           }
 
           $l++;

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -207,9 +207,6 @@ class Snappy extends Algorithm {
           }
           $pos+= 4;
           break;
-
-        default:
-          throw new IOException('Unexpected operation '.($c & 0x3));
       }
     }
 

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -62,14 +62,12 @@ class Snappy extends Algorithm {
     };
 
     // Compare 4-byte offsets in data at offsets a and b
-    $equals32= function($a, $b) use(&$data) {
-      return (
-        $data[$a] === $data[$b] &&
-        $data[$a + 1] === $data[$b + 1] &&
-        $data[$a + 2] === $data[$b + 2] &&
-        $data[$a + 3] === $data[$b + 3]
-      );
-    };
+    $equals32= fn($a, $b) => (
+      $data[$a] === $data[$b] &&
+      $data[$a + 1] === $data[$b + 1] &&
+      $data[$a + 2] === $data[$b + 2] &&
+      $data[$a + 3] === $data[$b + 3]
+    );
 
     $out= self::length(strlen($data));
     for ($emit= $pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -229,19 +229,10 @@ class Snappy extends Algorithm {
 
   /** Opens an output stream for writing */
   public function create(OutputStream $out, $options= null): OutputStream {
-
-    // FIXME Solve this without buffering
-    $self= $this;
-    return newinstance(OutputStream::class, [], [
-      'bytes' => '',
-      'write' => function($bytes) { $this->bytes.= $bytes; },
-      'flush' => function() { },
-      'close' => function() use($self, $out) {
-        if (null !== $this->bytes) {
-          $out->write($self->compress($this->bytes));
-          $this->bytes= null;
-        }
-      }
-    ]);
+    if (null !== ($length= Options::from($options)->length)) {
+      return new SnappyOutputStream($out, $length);
+    } else {
+      return new BufferedOutputStream($out, [$this, 'compress']);
+    }
   }
 }

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -70,7 +70,7 @@ class Snappy extends Algorithm {
     );
 
     $out= self::length(strlen($data));
-    for ($emit= $pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {
+    for ($pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {
       $fragment= min($length - $pos, self::BLOCK_SIZE);
       $end= $pos + $fragment;
       $emit= $pos;

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -40,7 +40,7 @@ class Snappy extends Algorithm {
   }
 
   /** Compresses data */
-  public function compress(string $data, int $level= Compression::DEFAULT): string {
+  public function compress(string $data, $options= null): string {
     static $literal, $copy;
 
     // Helper functions
@@ -228,7 +228,7 @@ class Snappy extends Algorithm {
   }
 
   /** Opens an output stream for writing */
-  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
+  public function create(OutputStream $out, $options= null): OutputStream {
 
     // FIXME Solve this without buffering
     $self= $this;

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -148,9 +148,10 @@ class Snappy extends Algorithm {
   /** Decompresses bytes */
   public function decompress(string $bytes): string {
     $out= '';
+    $pos= 0;
 
     // Read uncompressed length from varint
-    for ($length= $pos= $shift= 0, $c= 255; $shift < 32, $c >= 128; $pos++, $shift+= 7) {
+    for ($length= $shift= 0, $c= 255; $shift < 32, $c >= 128; $pos++, $shift+= 7) {
       $c= ord($bytes[$pos]);
       $length|= ($c & 0x7f) << $shift;
     }
@@ -163,14 +164,15 @@ class Snappy extends Algorithm {
         case 0:
           $l= $c >> 2;
           if (60 === $l) {
-            if ($pos + 1 >= $limit) throw new IOException('Position out of range');
+            if ($pos + 1 >= $limit) throw new IOException('Not enough input, expected 1');
             $l= unpack('C', $bytes, $pos)[1];
           } else if (61 === $l) {
-            if ($pos + 2 >= $limit) throw new IOException('Position out of range');
+            if ($pos + 2 >= $limit) throw new IOException('Not enough input, expected 2');
             $l= unpack('v', $bytes, $pos)[1];
           }
+
           $l++;
-          if ($pos + $l > $limit) throw new IOException('Not enough input for literal, expecting '.$l);
+          if ($pos + $l > $limit) throw new IOException('Not enough input, expected '.$l);
 
           $out.= substr($bytes, $pos, $l);
           $pos+= $l;
@@ -186,7 +188,7 @@ class Snappy extends Algorithm {
           break;
 
         case 2:
-          if ($pos + 1 >= $limit) throw new IOException('Position out of range');
+          if ($pos + 1 >= $limit) throw new IOException('Not enough input, expected 1');
 
           $l= 1 + ($c >> 2);
           $offset= unpack('v', $bytes, $pos)[1];
@@ -197,7 +199,7 @@ class Snappy extends Algorithm {
           break;
 
         case 3:
-          if ($pos + 3 >= $limit) throw new IOException('Position out of range');
+          if ($pos + 3 >= $limit) throw new IOException('Not enough input, expected 3');
 
           $l= 1 + ($c >> 2);
           $offset= unpack('V', $bytes, $pos)[1];

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -167,14 +167,11 @@ class Snappy extends Algorithm {
       switch ($c & 0x03) {
         case 0:
           $l= $c >> 2;
-          if (60 === $l) {
-            if ($pos + 1 >= $limit) throw new IOException('Not enough input, expected 1');
-            $l= unpack('C', $bytes, $pos)[1];
-            $pos++;
-          } else if (61 === $l) {
-            if ($pos + 2 >= $limit) throw new IOException('Not enough input, expected 2');
-            $l= unpack('v', $bytes, $pos)[1];
-            $pos+= 2;
+          if ($l >= 60) {
+            $n= $l - 59;
+            if ($pos + $n >= $limit) throw new IOException('Not enough input, expected '.$n);
+            $l= unpack('P', str_pad(substr($bytes, $pos, $n), 8, "\0"))[1];
+            $pos+= $n;
           }
 
           $l++;

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -61,6 +61,8 @@ class Snappy extends Algorithm {
 
   /** Compresses data */
   public function compress(string $data, $options= null): string {
+    $length= strlen($data);
+    $out= self::length($length);
 
     // Inlined comparison of 4-byte offsets in data at offsets a and b
     $equals32= fn($a, $b) => (
@@ -70,8 +72,7 @@ class Snappy extends Algorithm {
       $data[$a + 3] === $data[$b + 3]
     );
 
-    $out= self::length(strlen($data));
-    for ($pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {
+    for ($pos= 0; $pos < $length; $pos= $end) {
       $fragment= min($length - $pos, self::BLOCK_SIZE);
       $end= $pos + $fragment;
       $emit= $pos;

--- a/src/main/php/io/streams/compress/Snappy.class.php
+++ b/src/main/php/io/streams/compress/Snappy.class.php
@@ -1,0 +1,260 @@
+<?php namespace io\streams\compress;
+
+use io\IOException;
+use io\streams\{InputStream, OutputStream, Compression};
+
+/** @see https://en.wikipedia.org/wiki/Snappy_(compression) */
+class Snappy extends Algorithm {
+  const BLOCK_SIZE   = 65536;
+  const HASH_KEY     = 0x1e35a7bd;
+  const HASH_BITS    = 14;
+  const INPUT_MARGIN = 15;
+  const WORD_MASK    = [0, 0xff, 0xffff, 0xffffff, 0xffffffff];
+
+  /** Returns whether this algorithm is supported in the current setup */
+  public function supported(): bool { return true; }
+
+  /** Returns the algorithm's name */
+  public function name(): string { return 'snappy'; }
+
+  /** Returns the algorithm's HTTP Content-Encoding token */
+  public function token(): string { return 'snappy'; }
+
+  /** Returns the algorithm's common file extension, including a leading "." */
+  public function extension(): string { return '.sn'; }
+
+  /** Maps fastest, default and strongest levels */
+  public function level(int $select): int { return 0; }
+
+  /** Compresses data */
+  public function compress(string $data, int $level= Compression::DEFAULT): string {
+    static $literal, $copy;
+
+    // Helper functions
+    $literal ?? $literal= function($l) {
+      if ($l <= 60) {
+        return chr(($l - 1) << 2);
+      } else if ($l < 256) {
+        return pack('CC', 60 << 2, $l - 1);
+      } else {
+        return pack('CCC', 61 << 2, ($l - 1) & 0xff, (($l - 1) & 0xffffffff) >> 8);
+      }
+    };
+    $copy ?? $copy= function($i, $l) {
+      if ($l < 12 && $i < 2048) {
+        return pack('CC', 1 + (($l - 4) << 2) + ((($i & 0xffffffff) >> 8) << 5), $i & 0xff);
+      } else {
+        return pack('CCC', 2 + (($l - 1) << 2), $i & 0xff, ($i & 0xffffffff) >> 8);
+      }
+    };
+
+    $out= '';
+
+    // Output length as varint
+    $length= strlen($data);
+    shift: $l= $length & 0x7f;
+    $length= ($length & 0xffffffff) >> 7;
+    if ($length > 0) {
+      $out.= chr($l + 0x80);
+      goto shift;
+    }
+    $out.= chr($l);
+
+    // Compare 4-byte offsets in data at offsets a and b
+    $equals32= fn($a, $b) => (
+      $data[$a] === $data[$b] &&
+      $data[$a + 1] === $data[$b + 1] &&
+      $data[$a + 2] === $data[$b + 2] &&
+      $data[$a + 3] === $data[$b + 3]
+    );
+
+    for ($emit= $pos= 0, $end= $length= strlen($data); $pos < $length; $pos= $end) {
+      $fragment= min($length - $pos, self::BLOCK_SIZE);
+      $end= $pos + $fragment;
+      $emit= $pos;
+      if ($fragment <= self::INPUT_MARGIN) continue;
+
+      $bits= 1;
+      while ((1 << $bits) <= $fragment && $bits <= self::HASH_BITS) {
+        $bits++;
+      }
+      $bits--;
+      $shift= 32 - $bits;
+      $hashtable= array_fill(0, 1 << $bits, 0);
+
+      $start= $pos;
+      $limit= $end - self::INPUT_MARGIN;
+      $next= ((unpack('V', $data, ++$pos)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
+
+      // Emit literals
+      next: $forward= $pos;
+      $skip= 32;
+      do {
+        $pos= $forward;
+        $hash= $next;
+        $forward+= ($skip & 0xffffffff) >> 5;
+        $skip++;
+        if ($pos > $limit) continue 2;
+
+        $next= ((unpack('V', $data, $forward)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
+        $candidate= $start + $hashtable[$hash];
+        $hashtable[$hash]= ($pos - $start) & 0xffff;
+      } while (!$equals32($pos, $candidate));
+
+      $out.= $literal($pos - $emit).substr($data, $emit, $pos - $emit);
+
+      // Emit copy instructions
+      do {
+        $offset= $pos - $candidate;
+        $matched= 4;
+        while ($pos + $matched < $end && $data[$pos + $matched] === $data[$candidate + $matched]) {
+          $matched++;
+        }
+        $pos+= $matched;
+
+        while ($matched >= 68) {
+          $out.= $copy($offset, 64);
+          $matched-= 64;
+        }
+        if ($matched > 64) {
+          $out.= $copy($offset, 60);
+          $matched-= 60;
+        }
+        $out.= $copy($offset, $matched);
+        $emit= $pos;
+
+        if ($pos >= $limit) continue 2;
+
+        $hash= ((unpack('V', $data, $pos - 1)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
+        $hashtable[$hash]= ($pos - 1 - $start) & 0xffff;
+        $hash= ((unpack('V', $data, $pos)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
+        $candidate= $start + $hashtable[$hash];
+        $hashtable[$hash]= ($pos - $start) & 0xffff;
+      } while ($equals32($pos, $candidate));
+
+      $pos++;
+      $next= ((unpack('V', $data, $pos)[1] * self::HASH_KEY) & 0xffffffff) >> $shift;
+      goto next;
+    }
+
+    if ($emit < $end) {
+      $out.= $literal($end - $emit).substr($data, $emit, $end - $emit);
+    }
+
+    return $out;
+  }
+
+  /** Decompresses bytes */
+  public function decompress(string $bytes): string {
+    $out= '';
+
+    // Read uncompressed length from varint
+    for ($length= $pos= $shift= 0, $c= 255; $shift < 32, $c >= 128; $pos++, $shift+= 7) {
+      $c= ord($bytes[$pos]);
+      $length|= ($c & 0x7f) << $shift;
+    }
+
+    // Decompress using literal and copy operations
+    $end= strlen($bytes);
+    while ($pos < $end) {
+      $c= ord($bytes[$pos++]);
+      switch ($c & 0x03) {
+        case 0:
+          $l= 1 + ($c >> 2);
+          if ($l > 60) {
+            if ($pos + 3 >= $end) throw new IOException('Position out of range');
+
+            $s= $l - 60;
+            $l= unpack('V', $bytes, $pos)[1];
+            $l= ($l & self::WORD_MASK[$s]) + 1;
+            $pos+= $s;
+          }
+          if ($pos + $l > $end) throw new IOException('Not enough input for literal, expecting '.$l);
+
+          $out.= substr($bytes, $pos, $l);
+          $pos+= $l;
+          break;
+
+        case 1:
+          $l= 4 + (($c >> 2) & 0x7);
+          $offset= ord($bytes[$pos]) + (($c >> 5) << 8);
+          for ($i= 0, $end= strlen($out) - $offset; $i < $l; $i++) {
+            $out.= $out[$end + $i];
+          }
+          $pos++;
+          break;
+
+        case 2:
+          if ($pos + 1 >= $end) throw new IOException('Position out of range');
+
+          $l= 1 + ($c >> 2);
+          $offset= unpack('v', $bytes, $pos)[1];
+          for ($i= 0, $end= strlen($out) - $offset; $i < $l; $i++) {
+            $out.= $out[$end + $i];
+          }
+          $pos+= 2;
+          break;
+
+        case 3:
+          if ($pos + 3 >= $end) throw new IOException('Position out of range');
+
+          $l= 1 + ($c >> 2);
+          $offset= unpack('V', $bytes, $pos)[1];
+          for ($i= 0, $end= strlen($out) - $offset; $i < $l; $i++) {
+            $out.= $out[$end + $i];
+          }
+          $pos+= 4;
+          break;
+
+        default:
+          throw new IOException('Unexpected operation '.($c & 0x3));
+      }
+    }
+
+    // Verify uncompressed length
+    if ($length !== ($l= strlen($out))) {
+      throw new IOException('Expected length '.$length.', have '.$l);
+    }
+
+    return $out;
+  }
+
+  /** Opens an input stream for reading */
+  public function open(InputStream $in): InputStream {
+
+    // FIXME Solve this without buffering
+    $bytes= '';
+    while ($in->available()) {
+      $bytes.= $in->read();
+    }
+    return newinstance(InputStream::class, [], [
+      'pos'       => 0,
+      'bytes'     => $this->decompress($bytes),
+      'available' => function() { return strlen($this->bytes) - $this->pos; },
+      'read'      => function($limit= 4096) {
+        $chunk= substr($this->bytes, $this->pos, $limit);
+        $this->pos+= strlen($chunk);
+        return $chunk;
+      },
+      'close'     => function() { }
+    ]);
+  }
+
+  /** Opens an output stream for writing */
+  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
+
+    // FIXME Solve this without buffering
+    $self= $this;
+    return newinstance(OutputStream::class, [], [
+      'bytes' => '',
+      'write' => function($bytes) { $this->bytes.= $bytes; },
+      'flush' => function() { },
+      'close' => function() use($self, $out) {
+        if (null !== $this->bytes) {
+          $out->write($self->compress($this->bytes));
+          $this->bytes= null;
+        }
+      }
+    ]);
+  }
+}

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -59,10 +59,8 @@ class SnappyInputStream implements InputStream {
       switch ($c & 0x03) {
         case 0:
           $l= $c >> 2;
-          if (60 === $l) {
-            $l= unpack('C', $this->bytes(1))[1];
-          } else if (61 === $l) {
-            $l= unpack('v', $this->bytes(2))[1];
+          if ($l >= 60) {
+            $l= unpack('P', str_pad($this->bytes($l - 59), 8, "\0"))[1];
           }
           $this->out.= $this->bytes(++$l);
           break;

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -5,6 +5,8 @@ use io\streams\InputStream;
 
 /**
  * Snappy input stream
+ *
+ * @test  io.streams.compress.unittest.SnappyInputStreamTest
  */
 class SnappyInputStream implements InputStream {
   private $in, $out;

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -1,0 +1,140 @@
+<?php namespace io\streams\compress;
+
+use io\IOException;
+use io\streams\InputStream;
+
+/**
+ * Snappy input stream
+ */
+class SnappyInputStream implements InputStream {
+  private $in, $out;
+  private $read= 0;
+  private $buffer= '';
+
+  /**
+   * Returns a given amount of bytes from the buffer
+   *
+   * @param  int $n
+   * @return string
+   * @throws io.IOException
+   */
+  private function bytes($n) {
+    while (strlen($this->buffer) < $n) {
+      if ($this->in->available()) {
+        $this->buffer.= $this->in->read();
+      } else {
+        throw new IOException('Not enough input, expected '.$n);
+      }
+    }
+
+    $chunk= substr($this->buffer, 0, $n);
+    $this->buffer= substr($this->buffer, $n);
+    return $chunk;
+  }
+
+  /**
+   * Creates a new decompressing input stream
+   *
+   * @param  io.streams.InputStream $in The stream to read from
+   */
+  public function __construct(InputStream $in) {
+    $this->in= $in;
+    $this->out= '';
+    for ($shift= 0, $c= 255; $shift < 32, $c >= 128; $shift+= 7) {
+      $c= ord($this->bytes(1));
+      $this->read|= ($c & 0x7f) << $shift;
+    }
+  }
+
+  /**
+   * Read a string
+   *
+   * @param   int limit default 8192
+   * @return  string
+   */
+  public function read($limit= 8192) {
+    $pos= $start= strlen($this->out);
+    $limit= min($limit + $start, $this->read);
+
+    while ($pos < $limit) {
+      $c= ord($this->bytes(1));
+      switch ($c & 0x03) {
+        case 0:
+          $l= 1 + ($c >> 2);
+          if ($l > 60) {
+            $s= $l - 60;
+            $bytes= $this->bytes(4);
+            $l= unpack('V', $bytes)[1];
+            $l= ($l & Snappy::WORD_MASK[$s]) + 1;
+            $this->buffer= substr($bytes, $s).$this->buffer;
+          }
+          $this->out.= $this->bytes($l);
+          break;
+
+        case 1:
+          $l= 4 + (($c >> 2) & 0x7);
+          $offset= ord($this->bytes(1)) + (($c >> 5) << 8);
+          for ($i= 0, $end= strlen($this->out) - $offset; $i < $l; $i++) {
+            $this->out.= $this->out[$end + $i];
+          }
+          break;
+
+        case 2:
+          $l= 1 + ($c >> 2);
+          $offset= unpack('v', $this->bytes(2))[1];
+          for ($i= 0, $end= strlen($this->out) - $offset; $i < $l; $i++) {
+            $this->out.= $this->out[$end + $i];
+          }
+          break;
+
+        case 3:
+          $l= 1 + ($c >> 2);
+          $offset= unpack('V', $this->bytes(4))[1];
+          for ($i= 0, $end= strlen($this->out) - $offset; $i < $l; $i++) {
+            $this->out.= $this->out[$end + $i];
+          }
+          break;
+
+        default:
+          throw new IOException('Unexpected operation '.($c & 0x3));
+      }
+      $pos+= $l;
+    }
+
+    // Once block size is reached, offets never reference anything before.
+    if (strlen($this->out) > Snappy::BLOCK_SIZE) {
+      $chunk= substr($this->out, $start);
+      $this->out= substr($this->out, Snappy::BLOCK_SIZE);
+      $this->read-= Snappy::BLOCK_SIZE;
+      return $chunk;
+    }
+
+    return substr($this->out, $start);
+  }
+
+  /**
+   * Returns the number of bytes that can be read from this stream 
+   * without blocking.
+   *
+   * @return int
+   */
+  public function available() {
+    return $this->read - strlen($this->out);
+  }
+
+  /**
+   * Close this buffer.
+   *
+   * @return void
+   */
+  public function close() {
+    $this->in->close();
+  }
+  
+  /**
+   * Destructor. Ensures output stream is closed.
+   */
+  public function __destruct() {
+    $this->close();
+  }
+}

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -62,15 +62,13 @@ class SnappyInputStream implements InputStream {
       $c= ord($this->bytes(1));
       switch ($c & 0x03) {
         case 0:
-          $l= 1 + ($c >> 2);
-          if ($l > 60) {
-            $s= $l - 60;
-            $bytes= $this->bytes(4);
-            $l= unpack('V', $bytes)[1];
-            $l= ($l & Snappy::WORD_MASK[$s]) + 1;
-            $this->buffer= substr($bytes, $s).$this->buffer;
+          $l= $c >> 2;
+          if (60 === $l) {
+            $l= unpack('C', $this->bytes(1))[1];
+          } else if (61 === $l) {
+            $l= unpack('v', $this->bytes(2))[1];
           }
-          $this->out.= $this->bytes($l);
+          $this->out.= $this->bytes(++$l);
           break;
 
         case 1:

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -96,9 +96,6 @@ class SnappyInputStream implements InputStream {
             $this->out.= $this->out[$end + $i];
           }
           break;
-
-        default:
-          throw new IOException('Unexpected operation '.($c & 0x3));
       }
       $pos+= $l;
     }

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -3,11 +3,7 @@
 use io\IOException;
 use io\streams\InputStream;
 
-/**
- * Snappy input stream
- *
- * @test  io.streams.compress.unittest.SnappyInputStreamTest
- */
+/** @test io.streams.compress.unittest.SnappyInputStreamTest */
 class SnappyInputStream implements InputStream {
   private $in, $out;
   private $limit= 0;

--- a/src/main/php/io/streams/compress/SnappyInputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyInputStream.class.php
@@ -125,9 +125,7 @@ class SnappyInputStream implements InputStream {
     $this->in->close();
   }
   
-  /**
-   * Destructor. Ensures output stream is closed.
-   */
+  /** Ensures input stream is closed */
   public function __destruct() {
     $this->close();
   }

--- a/src/main/php/io/streams/compress/SnappyOutputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyOutputStream.class.php
@@ -54,14 +54,6 @@ class SnappyOutputStream implements OutputStream {
     $pos= $emit= 0;
     $out= '';
 
-    // Compare 4-byte offsets in data at offsets a and b
-    $equals32= fn($a, $b) => (
-      $this->buffer[$a] === $this->buffer[$b] &&
-      $this->buffer[$a + 1] === $this->buffer[$b + 1] &&
-      $this->buffer[$a + 2] === $this->buffer[$b + 2] &&
-      $this->buffer[$a + 3] === $this->buffer[$b + 3]
-    );
-
     if ($end >= Snappy::INPUT_MARGIN) {
       $bits= 1;
       while ((1 << $bits) <= $end && $bits <= Snappy::HASH_BITS) {
@@ -88,7 +80,7 @@ class SnappyOutputStream implements OutputStream {
         $next= ((unpack('V', $this->buffer, $forward)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
         $candidate= $start + $hashtable[$hash];
         $hashtable[$hash]= ($pos - $start) & 0xffff;
-      } while (!$equals32($pos, $candidate));
+      } while (!$this->equals32($pos, $candidate));
 
       $out.= $this->literal($pos - $emit).substr($this->buffer, $emit, $pos - $emit);
 
@@ -119,7 +111,7 @@ class SnappyOutputStream implements OutputStream {
         $hash= ((unpack('V', $this->buffer, $pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
         $candidate= $start + $hashtable[$hash];
         $hashtable[$hash]= ($pos - $start) & 0xffff;
-      } while ($equals32($pos, $candidate));
+      } while ($this->equals32($pos, $candidate));
 
       $pos++;
       $next= ((unpack('V', $this->buffer, $pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;

--- a/src/main/php/io/streams/compress/SnappyOutputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyOutputStream.class.php
@@ -143,4 +143,9 @@ class SnappyOutputStream implements OutputStream {
     }
     $this->out->close();
   }
+
+  /** Ensures output stream is closed */
+  public function __destruct() {
+    $this->close();
+  }
 }

--- a/src/main/php/io/streams/compress/SnappyOutputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyOutputStream.class.php
@@ -1,0 +1,162 @@
+<?php namespace io\streams\compress;
+
+use io\streams\OutputStream;
+
+/** @test io.streams.compress.unittest.SnappyOutputStreamTest */
+class SnappyOutputStream implements OutputStream {
+  private $out;
+  private $buffer= '';
+
+  /**
+   * Creates a new compressing output stream
+   *
+   * @param  io.streams.OutputStream $out The stream to write to
+   * @param  int $length uncompressed length
+   */
+  public function __construct(OutputStream $out, $length) {
+    $this->out= $out;
+    $this->out->write(Snappy::length($length));
+  }
+
+  /** Encode literal operation */
+  private function literal(int $l): string {
+    if ($l <= 60) {
+      return chr(($l - 1) << 2);
+    } else if ($l < 256) {
+      return pack('CC', 60 << 2, $l - 1);
+    } else {
+      return pack('CCC', 61 << 2, ($l - 1) & 0xff, (($l - 1) & 0xffffffff) >> 8);
+    }
+  }
+
+  /** Encode copy operation */
+  private function copy(int $i, int $l): string {
+    if ($l < 12 && $i < 2048) {
+      return pack('CC', 1 + (($l - 4) << 2) + ((($i & 0xffffffff) >> 8) << 5), $i & 0xff);
+    } else {
+      return pack('CCC', 2 + (($l - 1) << 2), $i & 0xff, ($i & 0xffffffff) >> 8);
+    }
+  }
+
+  /** Compare 4-byte offsets in data at offsets a and b */
+  private function equals32(int $a, int $b): bool {
+    return (
+      $this->buffer[$a] === $this->buffer[$b] &&
+      $this->buffer[$a + 1] === $this->buffer[$b + 1] &&
+      $this->buffer[$a + 2] === $this->buffer[$b + 2] &&
+      $this->buffer[$a + 3] === $this->buffer[$b + 3]
+    );
+  }
+
+  /** Compresses a fragment and returns last emitted position */
+  private function fragment() {
+    $end= min(strlen($this->buffer), Snappy::BLOCK_SIZE);
+    if ($end <= Snappy::INPUT_MARGIN) return 0;
+
+    $pos= $emit= 0;
+    $bits= 1;
+    while ((1 << $bits) <= $end && $bits <= Snappy::HASH_BITS) {
+      $bits++;
+    }
+    $bits--;
+    $shift= 32 - $bits;
+    $hashtable= array_fill(0, 1 << $bits, 0);
+
+    $start= $pos;
+    $limit= $end - Snappy::INPUT_MARGIN;
+    $next= ((unpack('V', $this->buffer, ++$pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
+
+    // Emit literals
+    next: $forward= $pos;
+    $skip= 32;
+    do {
+      $pos= $forward;
+      $hash= $next;
+      $forward+= ($skip & 0xffffffff) >> 5;
+      $skip++;
+      if ($pos > $limit) return $emit;
+
+      $next= ((unpack('V', $this->buffer, $forward)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
+      $candidate= $start + $hashtable[$hash];
+      $hashtable[$hash]= ($pos - $start) & 0xffff;
+    } while (!$this->equals32($pos, $candidate));
+
+    $this->out->write($this->literal($pos - $emit).substr($this->buffer, $emit, $pos - $emit));
+
+    // Emit copy instructions
+    do {
+      $offset= $pos - $candidate;
+      $matched= 4;
+      while ($pos + $matched < $end && $this->buffer[$pos + $matched] === $this->buffer[$candidate + $matched]) {
+        $matched++;
+      }
+      $pos+= $matched;
+
+      while ($matched >= 68) {
+        $this->out->write($this->copy($offset, 64));
+        $matched-= 64;
+      }
+      if ($matched > 64) {
+        $this->out->write($this->copy($offset, 60));
+        $matched-= 60;
+      }
+      $this->out->write($this->copy($offset, $matched));
+      $emit= $pos;
+
+      if ($pos >= $limit) return $emit;
+
+      $hash= ((unpack('V', $this->buffer, $pos - 1)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
+      $hashtable[$hash]= ($pos - 1 - $start) & 0xffff;
+      $hash= ((unpack('V', $this->buffer, $pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
+      $candidate= $start + $hashtable[$hash];
+      $hashtable[$hash]= ($pos - $start) & 0xffff;
+    } while ($this->equals32($pos, $candidate));
+
+    $pos++;
+    $next= ((unpack('V', $this->buffer, $pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
+    goto next;
+  }
+
+  /**
+   * Write a string
+   *
+   * @param  var $arg
+   * @return void
+   */
+  public function write($arg) {
+    if (strlen($this->buffer) <= Snappy::BLOCK_SIZE) {
+      $this->buffer.= $arg;
+    } else {
+      $this->buffer= substr($this->buffer, $this->fragment());
+    }
+  }
+
+  /**
+   * Flush this buffer (except if it's smaller than the input margin)
+   *
+   * @return void
+   */
+  public function flush() {
+    $this->buffer= substr($this->buffer, $this->fragment());
+  }
+
+  /**
+   * Closes this object. May be called more than once, which may
+   * not fail - that is, if the object is already closed, this 
+   * method should have no effect.
+   *
+   * @return void
+   */
+  public function close() {
+    $end= strlen($this->buffer);
+    if ($end > 0) {
+      $emit= $this->fragment();
+      if ($emit < $end) {
+        $this->out->write($this->literal($end - $emit).substr($this->buffer, $emit, $end - $emit));
+      }
+      $this->buffer= '';
+    }
+
+    $this->out->close();
+  }
+}

--- a/src/main/php/io/streams/compress/SnappyOutputStream.class.php
+++ b/src/main/php/io/streams/compress/SnappyOutputStream.class.php
@@ -63,7 +63,6 @@ class SnappyOutputStream implements OutputStream {
       $shift= 32 - $bits;
       $hashtable= array_fill(0, 1 << $bits, 0);
 
-      $start= $pos;
       $limit= $end - Snappy::INPUT_MARGIN;
       $next= ((unpack('V', $this->buffer, ++$pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
 
@@ -78,8 +77,8 @@ class SnappyOutputStream implements OutputStream {
         if ($pos > $limit || $forward > $limit) goto emit;
 
         $next= ((unpack('V', $this->buffer, $forward)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
-        $candidate= $start + $hashtable[$hash];
-        $hashtable[$hash]= ($pos - $start) & 0xffff;
+        $candidate= $hashtable[$hash];
+        $hashtable[$hash]= $pos & 0xffff;
       } while (!$this->equals32($pos, $candidate));
 
       $out.= $this->literal($pos - $emit).substr($this->buffer, $emit, $pos - $emit);
@@ -107,10 +106,10 @@ class SnappyOutputStream implements OutputStream {
         if ($pos >= $limit) goto emit;
 
         $hash= ((unpack('V', $this->buffer, $pos - 1)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
-        $hashtable[$hash]= ($pos - 1 - $start) & 0xffff;
+        $hashtable[$hash]= ($pos - 1) & 0xffff;
         $hash= ((unpack('V', $this->buffer, $pos)[1] * Snappy::HASH_KEY) & 0xffffffff) >> $shift;
-        $candidate= $start + $hashtable[$hash];
-        $hashtable[$hash]= ($pos - $start) & 0xffff;
+        $candidate= $hashtable[$hash];
+        $hashtable[$hash]= $pos & 0xffff;
       } while ($this->equals32($pos, $candidate));
 
       $pos++;

--- a/src/test/php/io/streams/compress/unittest/BufferedInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/BufferedInputStreamTest.class.php
@@ -1,0 +1,36 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\MemoryInputStream;
+use io\streams\compress\{BufferedInputStream, None};
+use lang\IllegalArgumentException;
+use test\{Assert, Expect, Test, Values};
+
+class BufferedInputStreamTest {
+
+  #[Test]
+  public function can_create_with_algorithm() {
+    new BufferedInputStream(new MemoryInputStream(''), new None());
+  }
+
+  #[Test]
+  public function can_create_with_function() {
+    new BufferedInputStream(new MemoryInputStream(''), fn($data) => $data);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function illegal_compress() {
+    new BufferedInputStream(new MemoryInputStream(''), null);
+  }
+
+  #[Test, Values([1, 8192, 8193, 65536])]
+  public function read_completely($repeat) {
+    $in= new BufferedInputStream(new MemoryInputStream($repeat), fn($data) => str_repeat('*', (int)$data));
+
+    $decompressed= '';
+    while ($in->available()) {
+      $decompressed.= $in->read();
+    }
+
+    Assert::equals($repeat, strlen($decompressed));
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
@@ -14,7 +14,7 @@ class BufferedOutputStreamTest {
 
   #[Test]
   public function can_create_with_function() {
-    new BufferedOutputStream(new MemoryOutputStream(), function($data) { return $data; });
+    new BufferedOutputStream(new MemoryOutputStream(), fn($data) => $data);
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
@@ -26,7 +26,7 @@ class BufferedOutputStreamTest {
   public function writes_on_close() {
     $out= new MemoryOutputStream();
 
-    $compress= new BufferedOutputStream($out, function($data) { return 'Z:'.strlen($data); });
+    $compress= new BufferedOutputStream($out, fn($data) => 'Z:'.strlen($data));
     $compress->write('Test');
     $compress->write('ed');
     $compress->close();

--- a/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
@@ -1,0 +1,36 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\MemoryOutputStream;
+use io\streams\compress\{BufferedOutputStream, None};
+use lang\IllegalArgumentException;
+use test\{Assert, Expect, Test};
+
+class BufferedOutputStreamTest {
+
+  #[Test]
+  public function can_create_with_algorithm() {
+    new BufferedOutputStream(new MemoryOutputStream(), new None());
+  }
+
+  #[Test]
+  public function can_create_with_function() {
+    new BufferedOutputStream(new MemoryOutputStream(), function($data) { return $data; });
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function illegal_compress() {
+    new BufferedOutputStream(new MemoryOutputStream(), null);
+  }
+
+  #[Test]
+  public function writes_on_close() {
+    $out= new MemoryOutputStream();
+
+    $compress= new BufferedOutputStream($out, function($data) { return 'Z:'.strlen($data); });
+    $compress->write('Test');
+    $compress->write('ed');
+    $compress->close();
+
+    Assert::equals('Z:6', $out->bytes());
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/BufferedOutputStreamTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace io\streams\compress\unittest;
 
-use io\streams\MemoryOutputStream;
 use io\streams\compress\{BufferedOutputStream, None};
+use io\streams\{OutputStream, MemoryOutputStream};
 use lang\IllegalArgumentException;
 use test\{Assert, Expect, Test};
 
@@ -32,5 +32,21 @@ class BufferedOutputStreamTest {
     $compress->close();
 
     Assert::equals('Z:6', $out->bytes());
+  }
+
+  #[Test]
+  public function closes_underlying_stream() {
+    $out= new class() implements OutputStream {
+      public $closed= false;
+      public function write($bytes) { }
+      public function flush() { }
+      public function close() { $this->closed= true; }
+    };
+
+    $compress= new BufferedOutputStream($out, new None());
+    $closed= $out->closed;
+    $compress->close();
+
+    Assert::equals([false, true], [$closed, $out->closed]);
   }
 }

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -48,6 +48,11 @@ class CompressionTest {
     if ($bzip2->supported() && PHP_VERSION_ID >= 70400) {
       yield [$bzip2, "BZh61AY&SY\331<Plain data>"];
     }
+
+    $snappy= $algorithms->named('snappy');
+    if ($snappy->supported()) {
+      yield [$snappy, "\002"];
+    }
   }
 
   #[Test]

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -56,7 +56,7 @@ class CompressionTest {
     foreach (Compression::algorithms() as $name => $algorithm) {
       $names[]= $name;
     }
-    Assert::equals(['gzip', 'bzip2', 'brotli'], $names);
+    Assert::equals(['gzip', 'bzip2', 'brotli', 'snappy'], $names);
   }
 
   #[Test]

--- a/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/CompressionTest.class.php
@@ -106,7 +106,7 @@ class CompressionTest {
 
   #[Test, Values(from: 'algorithms')]
   public function compress_roundtrip($compressed) {
-    $bytes= $compressed->compress('Test', Compression::DEFAULT);
+    $bytes= $compressed->compress('Test');
     $result= $compressed->decompress($bytes);
 
     Assert::equals('Test', $result);
@@ -116,7 +116,7 @@ class CompressionTest {
   public function streams_roundtrip($compressed) {
     $target= new MemoryOutputStream();
 
-    $out= $compressed->create($target, Compression::DEFAULT);
+    $out= $compressed->create($target);
     $out->write('Test');
     $out->close();
 

--- a/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
@@ -24,6 +24,16 @@ class SnappyInputStreamTest {
   }
 
   #[Test]
+  public function consecutive_literals() {
+    $ones= str_repeat('1', 255);
+    $twos= str_repeat('2', 255);
+    Assert::equals(
+      $ones.$twos,
+      Streams::readAll($this->fixture("\376\003\360\376{$ones}\360\376{$twos}"))
+    );
+  }
+
+  #[Test]
   public function copy() {
     Assert::equals(
       "Hello\n=================",

--- a/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
@@ -31,6 +31,11 @@ class SnappyInputStreamTest {
   }
 
   #[Test, Expect(IOException::class)]
+  public function from_empty() {
+    Streams::readAll($this->fixture(''));
+  }
+
+  #[Test, Expect(IOException::class)]
   public function not_enough_input() {
     Streams::readAll($this->fixture("\x01"));
   }

--- a/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
@@ -27,7 +27,7 @@ class SnappyInputStreamTest {
   public function copy() {
     Assert::equals(
       "Hello\n=================",
-      Streams::readAll($this->fixture("\026\030Hello\n=\076\001\000"))
+      Streams::readAll($this->fixture("\027\030Hello\n=\076\001\000"))
     );
   }
 

--- a/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
@@ -1,0 +1,37 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\IOException;
+use io\streams\compress\SnappyInputStream;
+use io\streams\{Streams, MemoryInputStream};
+use test\{Assert, Expect, Test};
+
+class SnappyInputStreamTest {
+
+  /** Creates a fixture */
+  private function fixture($bytes) {
+    return new SnappyInputStream(new MemoryInputStream($bytes));
+  }
+
+  #[Test]
+  public function can_create() {
+    $this->fixture("\x00");
+  }
+
+  #[Test]
+  public function literal() {
+    Assert::equals('Hello', Streams::readAll($this->fixture("\005\020Hello")));
+  }
+
+  #[Test]
+  public function copy() {
+    Assert::equals(
+      "Hello\n=================",
+      Streams::readAll($this->fixture("\026\030Hello\n=\076\001\000"))
+    );
+  }
+
+  #[Test, Expect(IOException::class)]
+  public function not_enough_input() {
+    Streams::readAll($this->fixture("\x01"));
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyInputStreamTest.class.php
@@ -3,7 +3,7 @@
 use io\IOException;
 use io\streams\compress\SnappyInputStream;
 use io\streams\{Streams, MemoryInputStream};
-use test\{Assert, Expect, Test};
+use test\{Assert, Expect, Test, Values};
 
 class SnappyInputStreamTest {
 
@@ -17,9 +17,10 @@ class SnappyInputStreamTest {
     $this->fixture("\x00");
   }
 
-  #[Test]
-  public function literal() {
-    Assert::equals('Hello', Streams::readAll($this->fixture("\005\020Hello")));
+  #[Test, Values([[5, "\005\020"], [255, "\377\001\360\376"], [256, "\200\002\364\377\000"]])]
+  public function literals($length, $encoded) {
+    $payload= str_repeat('*', $length);
+    Assert::equals($payload, Streams::readAll($this->fixture($encoded.$payload)));
   }
 
   #[Test]
@@ -30,12 +31,12 @@ class SnappyInputStreamTest {
     );
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(class: IOException::class, message: 'Not enough input, expected 1')]
   public function from_empty() {
     Streams::readAll($this->fixture(''));
   }
 
-  #[Test, Expect(IOException::class)]
+  #[Test, Expect(class: IOException::class, message: 'Not enough input, expected 1')]
   public function not_enough_input() {
     Streams::readAll($this->fixture("\x01"));
   }

--- a/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
@@ -1,0 +1,47 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\compress\SnappyOutputStream;
+use io\streams\{Streams, MemoryOutputStream};
+use test\{Assert, Test, Values};
+use util\Bytes;
+
+class SnappyOutputStreamTest {
+
+  /** Creates a fixture */
+  private function fixture($out, $length) {
+    return new SnappyOutputStream($out, $length);
+  }
+
+  #[Test]
+  public function can_create() {
+    $this->fixture(new MemoryOutputStream(), 0);
+  }
+
+  #[Test, Values([[0, "\000"], [5, "\005"], [255, "\377\001"], [256, "\200\002"], [65536, "\200\200\004"]])]
+  public function length_as_varint($length, $expected) {
+    $out= new MemoryOutputStream();
+    $this->fixture($out, $length);
+
+    Assert::equals(new Bytes($expected), new Bytes($out->bytes()));
+  }
+
+  #[Test]
+  public function literal() {
+    $out= new MemoryOutputStream();
+    $compress= $this->fixture($out, 5);
+    $compress->write('Hello');
+    $compress->close();
+
+    Assert::equals(new Bytes("\005\020Hello"), new Bytes($out->bytes()));
+  }
+
+  #[Test]
+  public function copy() {
+    $out= new MemoryOutputStream();
+    $compress= $this->fixture($out, 23);
+    $compress->write("Hello\n=================");
+    $compress->close();
+
+    Assert::equals(new Bytes("\027\030Hello\n=\076\001\000"), new Bytes($out->bytes()));
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
@@ -44,4 +44,17 @@ class SnappyOutputStreamTest {
 
     Assert::equals(new Bytes("\027\030Hello\n=\076\001\000"), new Bytes($out->bytes()));
   }
+
+  #[Test]
+  public function repeated_input_compressed() {
+    $out= new MemoryOutputStream();
+    $compress= $this->fixture($out, 20);
+    $compress->write('Hello');
+    $compress->write('Hello');
+    $compress->write('Hello');
+    $compress->write('Hello');
+    $compress->close();
+
+    Assert::equals(new Bytes("\024\020Hello:\005\000"), new Bytes($out->bytes()));
+  }
 }

--- a/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/SnappyOutputStreamTest.class.php
@@ -53,8 +53,9 @@ class SnappyOutputStreamTest {
     $compress->write('Hello');
     $compress->write('Hello');
     $compress->write('Hello');
+    $compress->write('!');
     $compress->close();
 
-    Assert::equals(new Bytes("\024\020Hello:\005\000"), new Bytes($out->bytes()));
+    Assert::equals(new Bytes("\024\020Hello:\005\000\000!"), new Bytes($out->bytes()));
   }
 }


### PR DESCRIPTION
> Snappy is widely used in Google projects like Bigtable, MapReduce and in compressing data for Google's internal RPC systems. It can be used in open-source projects like MariaDB ColumnStore, Cassandra, Couchbase, Hadoop, LevelDB, MongoDB, RocksDB, Lucene, Spark, Parquet, InfluxDB, and Ceph. Firefox uses Snappy to compress data in localStorage

* [x] Compression
* [x] Decompression
* [x] Input streaming
* [x] Output streaming

See https://en.wikipedia.org/wiki/Snappy_(compression), https://google.github.io/snappy/ and https://github.com/xp-forge/mongodb/pull/62#issuecomment-3124249231

* * * 

⚠️ Note: The streaming and string-based operations contain large amounts of duplicated code inlined and purpose-adopted for performance reasons!