### PR TITLE
Abstract algorithm options into an `Options` class

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,16 @@ Compression streams ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 2.0.0 / ????-??-??
+
+* **Heads up:** Algorithm implementations must change their `compress`
+  and `create` signatures from `$level= -1` to `$options= null`, and
+  can use `Options::from($options)->level` to access the given level
+  in a backwards-compatible fashion.
+  (@thekid)
+* Merged PR #12: Abstract algorithm options into an `Options` class
+  (@thekid)
+
 ## 1.4.0 / 2025-07-31
 
 * Merged PR #9: Add `Algorithm::compress()` and `Algorithm::decompress()`

--- a/src/main/php/io/streams/compress/Algorithm.class.php
+++ b/src/main/php/io/streams/compress/Algorithm.class.php
@@ -21,7 +21,7 @@ abstract class Algorithm implements Value {
   public abstract function level(int $select): int;
 
   /** Compresses data */
-  public abstract function compress(string $data, int $level= Compression::DEFAULT): string;
+  public abstract function compress(string $data, $options= null): string;
 
   /** Decompresses bytes */
   public abstract function decompress(string $bytes): string;
@@ -30,7 +30,7 @@ abstract class Algorithm implements Value {
   public abstract function open(InputStream $in): InputStream;
 
   /** Opens an output stream for writing */
-  public abstract function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream;
+  public abstract function create(OutputStream $out, $options= null): OutputStream;
 
   /** @return string */
   public function hashCode() { return crc32($this->name()); }

--- a/src/main/php/io/streams/compress/Brotli.class.php
+++ b/src/main/php/io/streams/compress/Brotli.class.php
@@ -23,8 +23,8 @@ class Brotli extends Algorithm {
   }
 
   /** Compresses data */
-  public function compress(string $data, int $level= Compression::DEFAULT): string {
-    return brotli_compress($data, $this->level($level));
+  public function compress(string $data, $options= null): string {
+    return brotli_compress($data, $this->level(Options::from($options)->level));
   }
 
   /** Decompresses bytes */
@@ -38,7 +38,7 @@ class Brotli extends Algorithm {
   }
 
   /** Opens an output stream for writing */
-  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
-    return new BrotliOutputStream($out, $this->level($level));
+  public function create(OutputStream $out, $options= null): OutputStream {
+    return new BrotliOutputStream($out, $this->level(Options::from($options)->level));
   }
 }

--- a/src/main/php/io/streams/compress/Bzip2.class.php
+++ b/src/main/php/io/streams/compress/Bzip2.class.php
@@ -24,8 +24,8 @@ class Bzip2 extends Algorithm {
   }
 
   /** Compresses data */
-  public function compress(string $data, int $level= Compression::DEFAULT): string {
-    return bzcompress($data, $this->level($level));
+  public function compress(string $data, $options= null): string {
+    return bzcompress($data, $this->level(Options::from($options)->level));
   }
 
   /** Decompresses bytes */
@@ -43,7 +43,7 @@ class Bzip2 extends Algorithm {
   }
 
   /** Opens an output stream for writing */
-  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
-    return new Bzip2OutputStream($out, $this->level($level));
+  public function create(OutputStream $out, $options= null): OutputStream {
+    return new Bzip2OutputStream($out, $this->level(Options::from($options)->level));
   }
 }

--- a/src/main/php/io/streams/compress/Gzip.class.php
+++ b/src/main/php/io/streams/compress/Gzip.class.php
@@ -24,8 +24,8 @@ class Gzip extends Algorithm {
   }
 
   /** Compresses data */
-  public function compress(string $data, int $level= Compression::DEFAULT): string {
-    return gzcompress($data, $this->level($level));
+  public function compress(string $data, $options= null): string {
+    return gzcompress($data, $this->level(Options::from($options)->level));
   }
 
   /** Decompresses bytes */
@@ -44,7 +44,7 @@ class Gzip extends Algorithm {
   }
 
   /** Opens an output stream for writing */
-  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
-    return new GzipOutputStream($out, $this->level($level));
+  public function create(OutputStream $out, $options= null): OutputStream {
+    return new GzipOutputStream($out, $this->level(Options::from($options)->level));
   }
 }

--- a/src/main/php/io/streams/compress/None.class.php
+++ b/src/main/php/io/streams/compress/None.class.php
@@ -20,7 +20,7 @@ class None extends Algorithm {
   public function level(int $select): int { return 0; }
 
   /** Compresses data */
-  public function compress(string $data, int $level= Compression::DEFAULT): string { return $data; }
+  public function compress(string $data, $options= null): string { return $data; }
 
   /** Decompresses bytes */
   public function decompress(string $bytes): string { return $bytes; }
@@ -31,7 +31,7 @@ class None extends Algorithm {
   }
 
   /** Opens an output stream for writing */
-  public function create(OutputStream $out, int $level= Compression::DEFAULT): OutputStream {
+  public function create(OutputStream $out, $options= null): OutputStream {
     return $out;
   }
 }

--- a/src/main/php/io/streams/compress/Options.class.php
+++ b/src/main/php/io/streams/compress/Options.class.php
@@ -1,0 +1,59 @@
+<?php namespace io\streams\compress;
+
+use io\streams\Compression;
+use lang\Value;
+use util\Comparison;
+
+/** @test io.streams.compress.unittest.OptionsTest */
+class Options implements Value {
+  use Comparison;
+
+  public $level, $length;
+
+  /**
+   * Compression options
+   * 
+   * @param  ?int $level
+   * @param  ?int $length
+   */
+  public function __construct(
+    $level= null,
+    $length= null
+  ) {
+    $this->level= $level ?? Compression::DEFAULT;
+    $this->length= $length;
+  }
+
+  /** @param ?int|[:var]|self $arg */
+  public static function from($arg): self {
+    if (null === $arg) {
+      return new self();
+    } else if ($arg instanceof self) {
+      return $arg;
+    } else if (is_array($arg)) {
+      return new self(
+        $arg['level'] ?? null,
+        $arg['length'] ?? null
+      );
+    } else {
+      return new self($arg);
+    }
+  }
+
+  /** @return string */
+  public function toString() {
+    switch ($this->level) {
+      case Compression::FASTEST: $level= 'FASTEST'; break;
+      case Compression::DEFAULT: $level= 'DEFAULT'; break;
+      case Compression::STRONGEST: $level= 'STRONGEST'; break;
+      default: $level= $this->level;
+    }
+
+    return sprintf(
+      '%s(level: %s, length: %s)',
+      nameof($this),
+      $level,
+      null === $this->length ? 'null' : $this->length
+    );
+  }
+}

--- a/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/AlgorithmsTest.class.php
@@ -15,10 +15,10 @@ class AlgorithmsTest {
       public function token(): string { return 'x-test'; }
       public function extension(): string { return '.test'; }
       public function level(int $select): int { return $select; }
-      public function compress(string $data, int $level= Compression::DEFAULT): string { return $data; }
+      public function compress(string $data, $options= null): string { return $data; }
       public function decompress(string $bytes): string { return $bytes; }
       public function open(InputStream $in): InputStream { return $in; }
-      public function create(OutputStream $out, int $method= Compression::DEFAULT): OutputStream { return $out; }
+      public function create(OutputStream $out, $options= null): OutputStream { return $out; }
     };
     $this->additional= new class() extends Algorithm {
       public function supported(): bool { return true; }
@@ -26,10 +26,10 @@ class AlgorithmsTest {
       public function token(): string { return 'x-add'; }
       public function extension(): string { return '.add'; }
       public function level(int $select): int { return $select; }
-      public function compress(string $data, int $level= Compression::DEFAULT): string { return $data; }
+      public function compress(string $data, $options= null): string { return $data; }
       public function decompress(string $bytes): string { return $bytes; }
       public function open(InputStream $in): InputStream { return $in; }
-      public function create(OutputStream $out, int $method= Compression::DEFAULT): OutputStream { return $out; }
+      public function create(OutputStream $out, $options= null): OutputStream { return $out; }
     };
     $this->unsupported= new class() extends Algorithm {
       public function supported(): bool { return false; }
@@ -37,10 +37,10 @@ class AlgorithmsTest {
       public function token(): string { return 'compress'; }
       public function extension(): string { return '.lz'; }
       public function level(int $select): int { return $select; }
-      public function compress(string $data, int $level= Compression::DEFAULT): string { return $data; }
+      public function compress(string $data, $options= null): string { return $data; }
       public function decompress(string $bytes): string { return $bytes; }
       public function open(InputStream $in): InputStream { return $in; }
-      public function create(OutputStream $out, int $method= Compression::DEFAULT): OutputStream { return $out; }
+      public function create(OutputStream $out, $options= null): OutputStream { return $out; }
     };
   }
 

--- a/src/test/php/io/streams/compress/unittest/OptionsTest.class.php
+++ b/src/test/php/io/streams/compress/unittest/OptionsTest.class.php
@@ -1,0 +1,87 @@
+<?php namespace io\streams\compress\unittest;
+
+use io\streams\Compression;
+use io\streams\compress\Options;
+use test\{Assert, Test, Values};
+
+class OptionsTest {
+  const LENGTH= 6100;
+
+  /** @return iterable */
+  private function maps() {
+    yield [[], Compression::DEFAULT, null];
+    yield [['unused' => -1], Compression::DEFAULT, null];
+    yield [['level' => Compression::FASTEST], Compression::FASTEST, null];
+    yield [['level' => Compression::FASTEST, 'length' => self::LENGTH], Compression::FASTEST, self::LENGTH];
+  }
+
+  #[Test]
+  public function can_create() {
+    new Options();
+  }
+
+  #[Test]
+  public function default_level() {
+    Assert::equals(Compression::DEFAULT, (new Options())->level);
+  }
+
+  #[Test]
+  public function default_length() {
+    Assert::null((new Options())->length);
+  }
+
+  #[Test, Values([Compression::FASTEST, Compression::DEFAULT, Compression::STRONGEST])]
+  public function level($level) {
+    Assert::equals($level, (new Options($level))->level);
+  }
+
+  #[Test]
+  public function length() {
+    Assert::equals(self::LENGTH, (new Options(null, self::LENGTH))->length);
+  }
+
+  #[Test]
+  public function from_level() {
+    Assert::equals(new Options(Compression::FASTEST, null), Options::from(Compression::FASTEST));
+  }
+
+  #[Test]
+  public function from_null() {
+    Assert::equals(new Options(Compression::DEFAULT, null), Options::from(null));
+  }
+
+  #[Test]
+  public function from_options() {
+    $options= new Options(Compression::FASTEST, self::LENGTH);
+    Assert::equals($options, Options::from($options));
+  }
+
+  #[Test, Values(from: 'maps')]
+  public function from($map, $level, $length) {
+    Assert::equals(new Options($level, $length), Options::from($map));
+  }
+
+  #[Test]
+  public function string_representation() {
+    Assert::equals(
+      'io.streams.compress.Options(level: DEFAULT, length: null)',
+      (new Options())->toString()
+    );
+  }
+
+  #[Test]
+  public function string_representation_with_length() {
+    Assert::equals(
+      'io.streams.compress.Options(level: DEFAULT, length: 6100)',
+      (new Options(null, self::LENGTH))->toString()
+    );
+  }
+
+  #[Test]
+  public function string_representation_with_level() {
+    Assert::equals(
+      'io.streams.compress.Options(level: 22, length: null)',
+      (new Options(22))->toString()
+    );
+  }
+}


### PR DESCRIPTION
Most compression algorithms only have one parameter: the compression level - GZip, for example, uses one between 0 and 9.

```php
use io\streams\Compression;
use io\streams\compress\Options;

$gzip= Compression::named('gzip');

// Use defaults
$gzip->compress($data);

// Pass in the compression level, backwards compatible
$gzip->compress($data, Compression::STRONGEST);

// Pass in an Options instance
$gzip->compress($data, new Options(level: Compression::STRONGEST));

// Pass in an a map of options, e.g. from a configuration file
$gzip->compress($data, ['level' => Compression::STRONGEST]);
```

Other algorithms may require other parameters. Snappy, for example, requires the uncompressed length upfront, see https://github.com/xp-forge/compression/pull/11#issuecomment-3148252379

```php
use io\File;
use io\streams\{Compression, FileInputStream, FileOutputStream};
use io\streams\compress\Options;

$snappy= Compression::named('snappy');

$in= new FileInputStream('README.md');
try {
  $out= $snappy->open(new FileOutputStream('README.sn')), new Options(length: $in->size()));
  while ($in->available()) {
    $out->write($in->read()):
  }
  $out->close();
} finally {
  $in->close();
}
```
